### PR TITLE
feat(pv-overrides): use excess energy to reach maximum temperature

### DIFF
--- a/AquaMQTT/include/config/Configuration.h
+++ b/AquaMQTT/include/config/Configuration.h
@@ -4,7 +4,7 @@
 /**
  * Possibility to include your own configuration file (added to .gitignore)
  */
-#define CUSTOM_CONFIGURATION
+//#define CUSTOM_CONFIGURATION
 
 #ifdef CUSTOM_CONFIGURATION
 #    include "CustomConfiguration.h"

--- a/AquaMQTT/include/config/Configuration.h
+++ b/AquaMQTT/include/config/Configuration.h
@@ -4,7 +4,7 @@
 /**
  * Possibility to include your own configuration file (added to .gitignore)
  */
-//#define CUSTOM_CONFIGURATION
+#define CUSTOM_CONFIGURATION
 
 #ifdef CUSTOM_CONFIGURATION
 #    include "CustomConfiguration.h"
@@ -49,8 +49,8 @@ constexpr bool OVERRIDE_TIME_AND_DATE_IN_MITM = true;
  */
 constexpr uint8_t  WATCHDOG_TIMEOUT_S    = 60;
 constexpr uint16_t MQTT_STATS_UPDATE_MS  = 5000;
-constexpr uint8_t  MQTT_MAX_TOPIC_SIZE   = 50;
-constexpr uint8_t  MQTT_MAX_PAYLOAD_SIZE = 50;
+constexpr uint8_t  MQTT_MAX_TOPIC_SIZE   = 80;
+constexpr uint8_t  MQTT_MAX_PAYLOAD_SIZE = 255;
 
 /**
  * Pin assignments for AquaMQTT Board Rev 1.0

--- a/AquaMQTT/include/config/ExampleConfiguration.h
+++ b/AquaMQTT/include/config/ExampleConfiguration.h
@@ -17,6 +17,30 @@ constexpr char brokerPassword[] = "";
 constexpr char mqttPrefix[]     = "";
 
 }  // namespace config
+
+namespace mqtt
+{
+// Optional and additional MQTT topics which are configured by the user.
+
+// Possibility to publish the current heat pump power to an additional mqtt topic of your choice.
+// Leave blank if not needed / unused
+constexpr char optionalPublishTopicHeatPumpCurrentPower[] = { /*"openWB/LegacySmartHome/set/Devices/1/Aktpower"*/ };
+
+// Possibility to publish the current heat element power to an additional mqtt topic of your choice.
+// Leave blank if not needed / unused
+constexpr char optionalPublishTopicHeatElementCurrentPower[] = { /*"openWB/LegacySmartHome/set/Devices/2/Aktpower"*/ };
+
+// Possibility to subscribe an additional mqtt topic for triggering the heat pump flag.
+// A boolean representation e.g "0" for unset and "1" for set is expected here.
+// Leave blank if not needed / unused
+constexpr char optionalSubscribeTopicSetPvHeatPumpFlag[] = { /*"openWB/LegacySmartHome/set/Devices/1/ReqRelay"*/ };
+
+// Possibility to subscribe an additional mqtt topic for triggering the heat element flag.
+// A boolean representation e.g "0" for unset and "1" for set is expected here.
+// Leave blank if not needed / unused
+constexpr char optionalSubscribeTopicSetPvHeatElementFlag[] = { /*"openWB/LegacySmartHome/set/Devices/2/ReqRelay"*/ };
+
+}  // namespace mqtt
 }  // namespace aquamqtt
 
 #endif  // AQUAMQTT_EXAMPLECONFIGURATION_H

--- a/AquaMQTT/include/message/HMIMessage.h
+++ b/AquaMQTT/include/message/HMIMessage.h
@@ -24,9 +24,9 @@ public:
 
     void setOperationMode(HMIOperationMode operationMode);
 
-    bool isTimerModeEnabled();
+    HMIOperationType getOperationType();
 
-    void setTimerModeEnabled(bool enabled);
+    void setOperationType(HMIOperationType operationType);
 
     bool isEmergencyModeEnabled();
 
@@ -81,6 +81,8 @@ public:
     uint8_t dateDay();
 
     void setDateDay(uint8_t day);
+
+    void setInstallationMode(HMIInstallation mode);
 
 private:
     uint8_t* mData;

--- a/AquaMQTT/include/message/MessageConstants.h
+++ b/AquaMQTT/include/message/MessageConstants.h
@@ -45,12 +45,31 @@ static const char* operationModeStr(HMIOperationMode mode)
     }
 }
 
+enum HMIOperationType : bool
+{
+    ALWAYS_ON = false,
+    TIMER     = true
+};
+
+static const char* operationTypeStr(HMIOperationType type)
+{
+    switch (type)
+    {
+        case ALWAYS_ON:
+            return reinterpret_cast<const char*>(mqtt::ENUM_OPERATION_TYPE_ALWAYS_ON);
+        case TIMER:
+            return reinterpret_cast<const char*>(mqtt::ENUM_OPERATION_TYPE_TIMER);
+        default:
+            return reinterpret_cast<const char*>(mqtt::ENUM_UNKNOWN);
+    }
+}
+
 enum HMIAirDuctConfig : int
 {
     AD_UNKNOWN = -1,
     AD_INT_INT = 0,   // Umluft
     AD_INT_EXT = 16,  // 1 Kanal Luftanschluss
-    AD_EXT_EXT = 32   // 2 Kanal Luftamschluss
+    AD_EXT_EXT = 32   // 2 Kanal Luftanschluss
 };
 
 static const char* airDuctConfigStr(HMIAirDuctConfig config)
@@ -106,16 +125,15 @@ static const char* testModeStr(HMITestMode config)
     }
 }
 
-
 enum HMIInstallation
 {
     INST_HP_UNKNOWN          = -1,
-    INST_HP_ONLY             = 0,  // 0000 0000
-    INST_HP_AND_EXT_PRIO_HP  = 1,  // 0000 0001
-    INST_HP_AND_EXT_OPT_HP   = 17, // 0001 0001
-    INST_HP_AND_EXT_OPT_EXT  = 33, // 0010 0001
-    INST_HP_AND_EXT_PRIO_EXT = 49, // 0011 0001
-    INST_HP_AND_SOLAR        = 2,  // 0000 0010
+    INST_HP_ONLY             = 0,   // 0000 0000
+    INST_HP_AND_EXT_PRIO_HP  = 1,   // 0000 0001
+    INST_HP_AND_EXT_OPT_HP   = 17,  // 0001 0001
+    INST_HP_AND_EXT_OPT_EXT  = 33,  // 0010 0001
+    INST_HP_AND_EXT_PRIO_EXT = 49,  // 0011 0001
+    INST_HP_AND_SOLAR        = 2,   // 0000 0010
 };
 
 static const char* installationModeStr(HMIInstallation installation)

--- a/AquaMQTT/include/mqtt/IMQTTCallback.h
+++ b/AquaMQTT/include/mqtt/IMQTTCallback.h
@@ -16,6 +16,24 @@ public:
     // $prefix/aquamqtt/ctrl/waterTempTarget + float
     virtual void onWaterTempTargetChanged(std::unique_ptr<float> value) = 0;
 
+    // $prefix/aquamqtt/ctrl/heatingElementEnabled + bool
+    virtual void onHeatingElementEnabledChanged(std::unique_ptr<bool> enabled) = 0;
+
+    // $prefix/aquamqtt/ctrl/emergencyModeEnabled + bool
+    virtual void onEmergencyModeEnabledChanged(std::unique_ptr<bool> enabled) = 0;
+
+    // $prefix/aquamqtt/ctrl/operationType + ENUM OPERATION TYPE
+    virtual void onOperationTypeChanged(std::unique_ptr<message::HMIOperationType> type) = 0;
+
+    // $prefix/aquamqtt/ctrl/configInstallation + ENUM INSTALLATION
+    virtual void onInstallationModeChanged(std::unique_ptr<message::HMIInstallation> mode) = 0;
+
+    // $prefic/aquamqtt/ctrl/flagPVModeHeatPump + bool
+    virtual void onPVModeHeatpumpEnabled(bool enabled) = 0;
+
+    // $prefic/aquamqtt/ctrl/flagPVModeHeatElement + bool
+    virtual void onPVModeHeatElementEnabled(bool enabled) = 0;
+
     // $prefix/aquamqtt/ctrl/reset
     virtual void onResetOverrides() = 0;
 };

--- a/AquaMQTT/include/mqtt/MQTTDefinitions.h
+++ b/AquaMQTT/include/mqtt/MQTTDefinitions.h
@@ -58,6 +58,11 @@ const char ENUM_SETUP_COMPLETED[] PROGMEM  = { "OK" };
 const char ENUM_SETUP_INCOMPLETE[] PROGMEM = { "PARTIAL RESET" };
 const char ENUM_SETUP_RESET[] PROGMEM      = { "FACTORY RESET" };
 
+const char ENUM_AQUAMQTT_OVERRIDE_MODE_DEFAULT[] PROGMEM = { "DEFAULT" };
+const char ENUM_AQUAMQTT_OVERRIDE_MODE_HP_ONLY[] PROGMEM = { "PV HP" };
+const char ENUM_AQUAMQTT_OVERRIDE_MODE_HE_ONLY[] PROGMEM = { "PV HE" };
+const char ENUM_AQUAMQTT_OVERRIDE_MODE_PV_FULL[] PROGMEM = { "PV BOOST" };
+
 // Subtopics
 const char MAIN_HOT_WATER_TEMP[] PROGMEM            = { "waterTemp" };
 const char MAIN_SUPPLY_AIR_TEMP[] PROGMEM           = { "supplyAirTemp" };
@@ -76,7 +81,7 @@ const char HMI_OPERATION_TYPE[] PROGMEM          = { "operationType" };
 const char HMI_TIME[] PROGMEM                    = { "time" };
 const char HMI_DATE[] PROGMEM                    = { "date" };
 const char HMI_TIME_AND_DATE[] PROGMEM           = { "time/date" };
-const char HMI_EMERGENCY_MODE[] PROGMEM          = { "emergencyMode" };
+const char HMI_EMERGENCY_MODE[] PROGMEM          = { "emergencyModeEnabled" };
 const char HMI_HEATING_ELEMENT_ENABLED[] PROGMEM = { "heatingElementEnabled" };
 const char HMI_LEGIONELLA[] PROGMEM              = { "antiLegionellaPerMonth" };
 const char HMI_TIMER_WINDOW_A[] PROGMEM          = { "timerWindowA" };
@@ -94,16 +99,19 @@ const char ENERGY_POWER_TOTAL[] PROGMEM              = { "powerTotal" };
 const char ENERGY_POWER_HEAT_ELEMENT[] PROGMEM       = { "powerHeatingElem" };
 const char ENERGY_POWER_HEATPUMP[] PROGMEM           = { "powerHeatpump" };
 
-const char STATS_AQUAMQTT_ADDR[] PROGMEM      = { "ipAddress" };
-const char STATS_AQUAMQTT_RSSI[] PROGMEM      = { "rssiDb" };
-const char STATS_AQUAMQTT_MODE[] PROGMEM      = { "aquamqttMode" };
-const char STATS_AQUAMQTT_LAST_WILL[] PROGMEM = { "lwlState" };
-const char STATS_MSG_HANDLED[] PROGMEM        = { "msgHandled" };
-const char STATS_MSG_UNHANDLED[] PROGMEM      = { "msgUnhandled" };
-const char STATS_MSG_SENT[] PROGMEM           = { "msgSent" };
-const char STATS_MSG_CRC_NOK[] PROGMEM        = { "msgCRCNOK" };
-const char STATS_DROPPED_BYTES[] PROGMEM      = { "droppedBytes" };
-const char STATS_ACTIVE_OVERRIDES[] PROGMEM   = { "activeOverrides" };
+const char STATS_AQUAMQTT_ADDR[] PROGMEM              = { "ipAddress" };
+const char STATS_AQUAMQTT_RSSI[] PROGMEM              = { "rssiDb" };
+const char STATS_AQUAMQTT_MODE[] PROGMEM              = { "aquamqttMode" };
+const char STATS_AQUAMQTT_OVERRIDE_MODE[] PROGMEM     = { "overrideMode" };
+const char STATS_AQUAMQTT_LAST_WILL[] PROGMEM         = { "lwlState" };
+const char STATS_MSG_HANDLED[] PROGMEM                = { "msgHandled" };
+const char STATS_MSG_UNHANDLED[] PROGMEM              = { "msgUnhandled" };
+const char STATS_MSG_SENT[] PROGMEM                   = { "msgSent" };
+const char STATS_MSG_CRC_NOK[] PROGMEM                = { "msgCRCNOK" };
+const char STATS_DROPPED_BYTES[] PROGMEM              = { "droppedBytes" };
+const char STATS_ACTIVE_OVERRIDES[] PROGMEM           = { "activeOverrides" };
+const char STATS_ENABLE_FLAG_PV_HEATPUMP[] PROGMEM    = { "flagPVModeHeatPump" };
+const char STATS_ENABLE_FLAG_PV_HEATELEMENT[] PROGMEM = { "flagPVModeHeatElement" };
 
 // CTRL
 const char AQUAMQTT_RESET_OVERRIDES[] PROGMEM = { "reset" };

--- a/AquaMQTT/include/state/HMIStateProxy.h
+++ b/AquaMQTT/include/state/HMIStateProxy.h
@@ -11,8 +11,37 @@ namespace aquamqtt
 struct AquaMqttOverrides
 {
     bool operationMode;
+    bool operationType;
     bool waterTempTarget;
+    bool heatingElementEnabled;
+    bool emergencyModeEnabled;
+    bool installationMode;
 };
+
+enum AquaMqttOverrideMode
+{
+    AM_MODE_STANDARD   = 0,
+    AM_MODE_PV_HP_ONLY = 1,
+    AM_MODE_PV_HE_ONLY = 2,
+    AM_MODE_PV_FULL    = 3
+};
+
+static const char* aquamqttOverrideStr(AquaMqttOverrideMode mode)
+{
+    switch (mode)
+    {
+        case AM_MODE_STANDARD:
+            return reinterpret_cast<const char*>(mqtt::ENUM_AQUAMQTT_OVERRIDE_MODE_DEFAULT);
+        case AM_MODE_PV_HP_ONLY:
+            return reinterpret_cast<const char*>(mqtt::ENUM_AQUAMQTT_OVERRIDE_MODE_HP_ONLY);
+        case AM_MODE_PV_HE_ONLY:
+            return reinterpret_cast<const char*>(mqtt::ENUM_AQUAMQTT_OVERRIDE_MODE_HE_ONLY);
+        case AM_MODE_PV_FULL:
+            return reinterpret_cast<const char*>(mqtt::ENUM_AQUAMQTT_OVERRIDE_MODE_PV_FULL);
+        default:
+            return reinterpret_cast<const char*>(mqtt::ENUM_UNKNOWN);
+    }
+}
 
 /**
  * HMIStateProxy accesses current HMI message from the DHW state
@@ -43,15 +72,35 @@ public:
 
     void onOperationModeChanged(std::unique_ptr<message::HMIOperationMode> value) override;
 
+    void onOperationTypeChanged(std::unique_ptr<message::HMIOperationType> type) override;
+
+    void onInstallationModeChanged(std::unique_ptr<message::HMIInstallation> mode) override;
+
     void onWaterTempTargetChanged(std::unique_ptr<float> value) override;
+
+    void onHeatingElementEnabledChanged(std::unique_ptr<bool> enabled) override;
+
+    void onEmergencyModeEnabledChanged(std::unique_ptr<bool> enabled) override;
+
+    void onPVModeHeatpumpEnabled(bool enabled) override;
+
+    bool isPVModeHeatPumpEnabled();
+
+    void onPVModeHeatElementEnabled(bool enabled) override;
+
+    bool isPVModeHeatElementEnabled();
 
     void onResetOverrides() override;
 
     AquaMqttOverrides getOverrides();
 
+    AquaMqttOverrideMode getOverrideMode();
+
     void updateTime(uint8_t seconds, uint8_t minutes, uint8_t hours, uint8_t days, uint8_t month, uint16_t year);
 
 private:
+    AquaMqttOverrideMode currentOverrideMode() const;
+
     TaskHandle_t      mNotify;
     SemaphoreHandle_t mMutex;
     bool              mTimeIsSet;
@@ -64,7 +113,13 @@ private:
 
     // since we do not have optionals, use nullptr if override is not set
     std::unique_ptr<float>                     mTargetTemperature;
+    std::unique_ptr<message::HMIOperationType> mOperationType;
     std::unique_ptr<message::HMIOperationMode> mOperationMode;
+    std::unique_ptr<message::HMIInstallation>  mInstallationMode;
+    std::unique_ptr<bool>                      mEmergencyModeEnabled;
+    std::unique_ptr<bool>                      mHeatingElementEnabled;
+    bool                                       mPVModeHeatPump;
+    bool                                       mPVModeHeatElement;
 };
 
 }  // namespace aquamqtt

--- a/AquaMQTT/platformio.ini
+++ b/AquaMQTT/platformio.ini
@@ -24,8 +24,8 @@ framework = arduino
 test_framework = googletest
 build_flags = -std=c++11
 # uncomment the below lines to use over the air update
-upload_protocol = espota
-upload_port = 192.168.188.62
+# upload_protocol = espota
+# upload_port = 192.168.188.62
 lib_deps =
     locoduino/RingBuffer
     FrankBoesing/FastCRC

--- a/AquaMQTT/platformio.ini
+++ b/AquaMQTT/platformio.ini
@@ -24,8 +24,8 @@ framework = arduino
 test_framework = googletest
 build_flags = -std=c++11
 # uncomment the below lines to use over the air update
-# upload_protocol = espota
-# upload_port = 192.168.188.62
+#upload_protocol = espota
+#upload_port = 192.168.188.62
 lib_deps =
     locoduino/RingBuffer
     FrankBoesing/FastCRC

--- a/AquaMQTT/platformio.ini
+++ b/AquaMQTT/platformio.ini
@@ -24,8 +24,8 @@ framework = arduino
 test_framework = googletest
 build_flags = -std=c++11
 # uncomment the below lines to use over the air update
-#upload_protocol = espota
-#upload_port = 192.168.188.62
+upload_protocol = espota
+upload_port = 192.168.188.62
 lib_deps =
     locoduino/RingBuffer
     FrankBoesing/FastCRC

--- a/MQTT.md
+++ b/MQTT.md
@@ -19,7 +19,7 @@ Using the prefix, the `$root` topic is created, which is `$prefix/aquamqtt/` and
 |----------------------------------|---------------------------------------|--------|------|--------------------------------------------------|
 | Last Will               | `$root/stats/lwlState`                |   Enum |      |                                ONLINE, OFFLINE  -- retained|
 | OperationMode           | `$root/stats/aquamqttMode`            |   Enum |      |                                 LISTENER, MITM   |
-| Active Overrides        | `$root/stats/activeOverrides` | json | | Active Overrides are flagged either with 1 (overriden) or 0 (not overriden)  Example Payload:  `{ "operationMode": 0, "operationType": 0, "waterTempTarget": 0, "heatingElementEnabled": 0, "emergencyModeEnabled": 0, "time/date": 1 }`   |
+| Active Overrides        | `$root/stats/activeOverrides` | json | | Active Overrides are flagged either with 1 (overriden) or 0 (not overriden)  Example Payload:  `{ "operationMode": 0, "operationType": 0, "waterTempTarget": 0, "heatingElementEnabled": 0, "emergencyModeEnabled": 0, "configInstallation": 0 , "time/date": 1 }`   |
 | Override Modes         | `$root/stats/overrideMode` | Enum | | `STANDARD`, `PV HP`, `PV HE` or `PV BOOST`. See [README-PV.md](/README-PV.md) for additional information.   |
 | Flag PV heat pump      | `$root/stats/flagPVModeHeatPump` | bool | | Status of the pv heat pump flag. See [README-PV.md](/README-PV.md) for additional information.   |
 | Flag PV heat element   | `$root/stats/flagPVModeHeatElement` | bool | | Status of the pv heat element flag. See [README-PV.md](/README-PV.md) for additional information.   |
@@ -93,8 +93,8 @@ Using this topics you may override the HMI Controller in AquaMQTT OperationMode 
 | Installation Config                   | `$root/ctrl/configInstallation`       |   Enum |      |       "`HEAT PUMP ONLY`", "`BOILER BACKUP / HEAT PUMP PRIORITY"`", "`...`" | Overrides the installation config  |
 | Enable or disable heating element | `$root/ctrl/heatingElementEnabled`       |   bool |      |       "`1`" | Allow the DHW heat pump to use the heating element if needed. Sanity: It is not possible to disable the heating element in case emergency mode is enabled.|
 | Enable or disable emergency mode  | `$root/ctrl/emergencyModeEnabled`       |   bool |      |       "`0`" | Forces the DHW heat pump to use only the heating element. Sanity: it is not possible to enable emergency mode if heating element has been disabled. |
-| Set PV Mode Heat Pump Flag                 | `$root/ctrl/flagPVModeHeatPump`       |   bool|      |        | See [README-PV.md](/README-PV.md) additional information. Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h`  |
-| Set PV Mode Heat Element Flag                 | `$root/ctrl/flagPVModeHeatPump`       |   bool|      |        | See [README-PV.md](/README-PV.md) for additional information. Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h`  |
+| Set PV Mode Heat Pump Flag                 | `$root/ctrl/flagPVModeHeatPump`       |   bool|      |  "`1`"       | See [README-PV.md](/README-PV.md) additional information. Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h`  |
+| Set PV Mode Heat Element Flag                 | `$root/ctrl/flagPVModeHeatPump`       |   bool|      |   "`1`"      | See [README-PV.md](/README-PV.md) for additional information. Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h`  |
 | Reset Overrides                  | `$root/ctrl/reset`       |   Void |      |        | Removes all previous set overrides. |
 
 **Note:** Calling a `ctrl` topic with an empty payload `""` will reset individual override.

--- a/MQTT.md
+++ b/MQTT.md
@@ -17,15 +17,19 @@ Using the prefix, the `$root` topic is created, which is `$prefix/aquamqtt/` and
 
 | Value                            |                            MQTT Topic | Format | Unit |                                Other Information |
 |----------------------------------|---------------------------------------|--------|------|--------------------------------------------------|
-| AquaMQTT Last Will               | `$root/stats/lwlState`                |   Enum |      |                                ONLINE, OFFLINE  -- retained|
-| AquaMQTT OperationMode           | `$root/stats/aquamqttMode`            |   Enum |      |                                 LISTENER, MITM   |
-| AquaMQTT IP Address              | `$root/stats/ipAddress`               | string |      |                            e.g. 192.168.188.62   |
-| AquaMQTT RSSI                    | `$root/stats/rssiDb`                  |    int |   dB |                                                  |
-| AquaMQTT Messages OK             | `$root/stats/$channel/msgHandled`     | uint64 |      |                                                  |
-| AquaMQTT Messages IGNORED        | `$root/stats/$channel/msgUnhandled`   | uint64 |      |                                                  |
-| AquaMQTT Messages CRC NOK        | `$root/stats/$channel/msgCRCNOK`      | uint64 |      |                                                  |
-| AquaMQTT Dropped Bytes           | `$root/stats/$channel/droppedBytes`   | uint64 |      |                                                  |
-| AquaMQTT Active Overrides        | `$root/stats/$channel/activeOverrides` | ListOfEnum | |    e.g. "["time/date", "operationMode", "waterTempTarget"]"   |
+| Last Will               | `$root/stats/lwlState`                |   Enum |      |                                ONLINE, OFFLINE  -- retained|
+| OperationMode           | `$root/stats/aquamqttMode`            |   Enum |      |                                 LISTENER, MITM   |
+| Active Overrides        | `$root/stats/activeOverrides` | json | | Active Overrides are flagged either with 1 (overriden) or 0 (not overriden)  Example Payload:  `{ "operationMode": 0, "operationType": 0, "waterTempTarget": 0, "heatingElementEnabled": 0, "emergencyModeEnabled": 0, "time/date": 1 }`   |
+| Override Modes         | `$root/stats/overrideMode` | Enum | | `STANDARD`, `PV HP`, `PV HE` or `PV BOOST`. See [README-PV.md](/README-PV.md) for additional information.   |
+| Flag PV heat pump      | `$root/stats/flagPVModeHeatPump` | bool | | Status of the pv heat pump flag. See [README-PV.md](/README-PV.md) for additional information.   |
+| Flag PV heat element   | `$root/stats/flagPVModeHeatElement` | bool | | Status of the pv heat element flag. See [README-PV.md](/README-PV.md) for additional information.   |
+| IP Address              | `$root/stats/ipAddress`               | string |      |                            e.g. 192.168.188.62   |
+| RSSI                    | `$root/stats/rssiDb`                  |    int |   dB |                                                  |
+| Messages OK             | `$root/stats/$channel/msgHandled`     | uint64 |      |                                                  |
+| Messages IGNORED        | `$root/stats/$channel/msgUnhandled`   | uint64 |      |                                                  |
+| Messages CRC NOK        | `$root/stats/$channel/msgCRCNOK`      | uint64 |      |                                                  |
+| Dropped Bytes           | `$root/stats/$channel/droppedBytes`   | uint64 |      |                                                  |
+
 
 `$channel` is either `hmi` and `main` or `listener` depending on the AquaMQTT operation mode.
 
@@ -73,8 +77,8 @@ Using the prefix, the `$root` topic is created, which is `$prefix/aquamqtt/` and
 | Total Heating Element Hours      | `$root/energy/totalHeatingElemHours`  | uint32 |    h |                                           retained       |
 | Total Hours                      | `$root/energy/totalHours`             | uint32 |    h |                                            retained      |
 | Total Energy                     | `$root/energy/totalEnergyWh`          | uint64 |   Wh |                                                  |
-| Current Power Heatpump           | `$root/energy/powerHeatpump`          | uint16 |    W |                                                  |
-| Current Power Heating Element    | `$root/energy/powerHeatingElem`       | uint16 |    W |                                                  |
+| Current Power Heatpump           | `$root/energy/powerHeatpump`          | uint16 |    W | Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h`                                                 |
+| Current Power Heating Element    | `$root/energy/powerHeatingElem`       | uint16 |    W | Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h`                                                            |
 | Current Power Total              | `$root/energy/powerTotal`             | uint16 |    W |                                                  |
 
 ## Subscribe Topics
@@ -85,7 +89,12 @@ Using this topics you may override the HMI Controller in AquaMQTT OperationMode 
 |----------------------------------|----------------------------------|--------|------|-----------------|-------------------------------------------------|
 | Target Water Temperature         | `$root/ctrl/waterTempTarget`     | float  |   °C |        "`55.0`" | Overrides the water temperature target: Allowed range is from 20°C to 62°C. |
 | Operation Mode                   | `$root/ctrl/operationMode`       |   Enum |      |       "`BOOST`" | Overrides the operation mode, may affect the waterTempTarget. For example BOOST and ABSENCE will automatically set the waterTempTarget accordingly.  |
+| Operation Type                    | `$root/ctrl/operationType`       |   Enum |      |       "`ALWAYS ON`" | Overrides the operation type  |
+| Installation Config                   | `$root/ctrl/configInstallation`       |   Enum |      |       "`HEAT PUMP ONLY`", "`BOILER BACKUP / HEAT PUMP PRIORITY"`", "`...`" | Overrides the installation config  |
+| Enable or disable heating element | `$root/ctrl/heatingElementEnabled`       |   bool |      |       "`1`" | Allow the DHW heat pump to use the heating element if needed. Sanity: It is not possible to disable the heating element in case emergency mode is enabled.|
+| Enable or disable emergency mode  | `$root/ctrl/emergencyModeEnabled`       |   bool |      |       "`0`" | Forces the DHW heat pump to use only the heating element. Sanity: it is not possible to enable emergency mode if heating element has been disabled. |
+| Set PV Mode Heat Pump Flag                 | `$root/ctrl/flagPVModeHeatPump`       |   bool|      |        | See [README-PV.md](/README-PV.md) additional information. Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h`  |
+| Set PV Mode Heat Element Flag                 | `$root/ctrl/flagPVModeHeatPump`       |   bool|      |        | See [README-PV.md](/README-PV.md) for additional information. Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h`  |
 | Reset Overrides                  | `$root/ctrl/reset`       |   Void |      |        | Removes all previous set overrides. |
-
 
 **Note:** Calling a `ctrl` topic with an empty payload `""` will reset individual override.

--- a/README-PV.md
+++ b/README-PV.md
@@ -1,0 +1,98 @@
+# PV Modes
+
+AquaMqtt has been built to utilize local end excess energy produced by photovoltaic energy sources. For doing so, AquaMQTT provides additional operation modes to turn on either heat pump and/or heat element to reach the maximum water temperature. These operation modes can be enabled using two flags which are signaled via [MQTT](./MQTT.md). These flags override various HMI attributes:
+
+## Default
+
+```C
+flagPVModeHeatPump = false;
+flagPVModeHeatElement = false;
+```
+
+Default AquaMQTT behaviour: AquaMQTT will use any overrides which have been previously set via MQTT control topics.
+
+## PV Heat-Pump Only (PV HP)
+
+```C
+flagPVModeHeatPump = true;
+flagPVModeHeatElement = false;
+```
+
+The heat pump will try to reach maximum allowed temperature using the heat pump, without usage of the heating element. This will consume between 300 and 550W of power, depending on the current water temperature and air temperature.
+
+Active Overrides:
+- Installation Mode is set to `HEATPUMP ONLY` (we don't want to use an external boiler if any connected)
+- OperationMode is set to "`MAN ECO OFF`"
+- OperationType is set to "`ALWAYS ON`"
+- Water Temperature is set to `62°C`
+- Heating Element is set to `disabled`
+- Emergeny Mode is turned `off`
+- Consumes about `300 - 550W`
+
+*Any other previously set overrides are ignored, if this mode is active!*
+
+## PV Heat-Element Only (PV HE)
+
+```C
+flagPVModeHeatPump = false;
+flagPVModeHeatElement = true;
+```
+
+The heat pump will try to reach maximum allowed temperate using the heating element, without usage of the heat pump. This will consume 1600W of power.
+
+- Installation Mode is set to `HEATPUMP ONLY` (we don't want to use an external boiler if any connected)
+- OperationMode is set to "`MAN ECO OFF`"
+- OperationType is set to "`ALWAYS ON`"
+- Water Temperature is set to `62°C`
+- Heating Element is set to `enabled`
+- Emergency Mode is turned `on` (forces usage of heat element)
+- Consumes `1600W`
+
+*Any other previously set overrides are ignored, if this mode is active!*
+
+## PV BOOST
+
+```C
+flagPVModeHeatPump = true;
+flagPVModeHeatElement = true;
+```
+
+If both flags are set, the heat pump will enter the enter OperationMode "`BOOST`" and therefore utilize both heat pump and heat element to reach and keep maximum temperature.
+
+- Installation Mode is set to `HEATPUMP ONLY` (we don't want to use an external boiler if any connected)
+- OperationMode is set to "`BOOST`"
+- OperationType is set to "`ALWAYS ON`"
+- Water Temperature is set to `62°C`
+- Heating Element is set to `enabled`
+- Consumes `1600W` + `300 - 550W`
+
+*Any other previously set overrides are ignored, if this mode is active!*
+
+## How to trigger the flags?
+
+The flags can be triggered using the [MQTT](./MQTT.md) control topics. The current PV mode and the status of the pv flags is also provided within the stats section.
+
+| Value                            |                            MQTT Topic | Format |                                Other Information |
+|----------------------------------|---------------------------------------|-------|--------------------------------------------------|
+| Override Modes         | `$root/stats/overrideMode` | Enum |  `DEFAULT`, `PV HP`, `PV HE` or `PV BOOST`   |
+| Flag PV heat pump      | `$root/stats/flagPVModeHeatPump` | bool | Status of the pv heat pump flag  |
+| Flag PV heat element   | `$root/stats/flagPVModeHeatElement` | bool | Status of the pv heat element flag
+| Set PV Mode Heat Pump Flag                 | `$root/ctrl/flagPVModeHeatPump`       |   bool           | Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h`  |
+| Set PV Mode Heat Element Flag                 | `$root/ctrl/flagPVModeHeatPump`       |   bool           |  Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h`  |
+   |
+
+## How to automate?
+
+I am using my [OpenWB](https://github.com/snaptec/openWB) device for determining excess energy and turning on/off smart home devices. AquaMQTT is represented as two smart home devices in openWB, and is triggered automatically on various energy excess levels.
+
+Any other solution triggering smart home devices on energy excess might work similar. You may provide custom mqtt topics to `Configuration.h` if needed.
+
+```C++
+constexpr char optionalPublishTopicHeatPumpCurrentPower[] = { "openWB/LegacySmartHome/set/Devices/1/Aktpower" };
+
+constexpr char optionalPublishTopicHeatElementCurrentPower[] = { "openWB/LegacySmartHome/set/Devices/2/Aktpower" };
+
+constexpr char optionalSubscribeTopicSetPvHeatPumpFlag[] = { "openWB/LegacySmartHome/set/Devices/1/ReqRelay" };
+
+constexpr char optionalSubscribeTopicSetPvHeatElementFlag[] = { "openWB/LegacySmartHome/set/Devices/2/ReqRelay" };
+```

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ AquaMQTT is a project designed to monitor and control your DHW heat pump locally
 - Easily integrate AquaMQTT with smart home systems like [Home Assistant](https://www.home-assistant.io/).
 
 <p float="left">
-   <img src="../media/homeassistant.png?raw=true" width=40% height=40%>
-   <img src="../media/aquamqtt.jpg?raw=true" width=55% height=55%>
+   <img src="../media/homeassistant.png?raw=true" width=35% height=35%>
+   <img src="../media/aquamqtt.jpg?raw=true" width=60% height=60%>
 </p>
 
 

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ Unfortunately, I had no success pairing those solutions with my Windhager brande
 
 - [Available MQTT Topics and Payloads](./MQTT.md)
 
-- [Utilize excess local energy using PV modes](/.README-PV.md)
+- [Utilize excess local energy using PV modes](./README-PV.md)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AquaMQTT is a project designed to monitor and control your DHW heat pump locally
 
 - Access sensor data and operational states from your heat pump.
 - Control the heat pump: Set operational states e.g. water temperature and operation modes.
-- Automate the behavior of your heat pump according to your local energy production or energy availability.
+- [Automate the behavior of your heat pump according to your local energy production or energy availability](/README-PV.md)
 - Easily integrate AquaMQTT with smart home systems like [Home Assistant](https://www.home-assistant.io/).
 
 <p float="left">
@@ -18,7 +18,6 @@ AquaMQTT is a project designed to monitor and control your DHW heat pump locally
 
 
 ## Compatible Devices
-
 
 AquaMQTT is designed and tested with the [Windhager AquaWin Air3](https://www.windhager.com/en/products/hot-water-tanks/aquawin-air3/) DHW heat pump. While specifically tailored to this model, it's highly likely that AquaMQTT is compatible with similar heat pumps manufactured by the [Groupe Atlantic](https://www.groupe-atlantic.fr/) and branded for various companies.
 
@@ -39,28 +38,23 @@ To achieve this communication interception, an Arduino-based microcontroller is 
 
 AquaMQTT not only monitors the heat pump's status but also provides the capability to control it by modifying the messages originating from the HMI controller. This allows you to set operational states, such as water temperature and operation modes, directly through AquaMQTT.
 
-In summary:
-- AquaMQTT intercepts and processes serial messages between controllers.
-- Extracted values are published via MQTT.
-- An Arduino-based microcontroller facilitates communication interception.
-- AquaMQTT can modify messages to control the heat pump's operational states.
-
-
 ## Getting Started
 
-To get started with monitoring and controlling your heat pump, follow these steps:
+- [Hardware Requirements](/pcb) 
 
-1. **Hardware (AquaMQTT Board):**
-   - Before proceeding, make sure to place an order for the custom PCB with a manufacturing company. You can locate the KiCad files and further instructions within the [pcb](/pcb) folder.
+- [Software Installation](AquaMQTT/README.md)
 
-2. **AquaMQTT Software:**
-   - [Install AquaMQTT to your Arduino ESP32 using PlatformIO](AquaMQTT/README.md).
+- [Heatpump Modification](./WIRING.md)
 
-3. **Wiring Instructions:**
-   - Follow the instructions in [WIRING.md](./WIRING.md) to integrate the AquaMQTT Board into your heat pump. This document includes details on connecting the PCB to the HMI controller and the main controller.
 
 ## Why not using cozytouch / io-homecontrol?
 
 Unfortunately, I had no success pairing those solutions with my Windhager branded heatpump.
 
+## Further Reading
 
+- [Heat pump serial protocol](./PROTOCOL.md)
+
+- [Available MQTT Topics and Payloads](./MQTT.md)
+
+- [Utilize excess local energy using PV modes](/.README-PV.md)


### PR DESCRIPTION
# PV Modes

AquaMQTT has been built to utilize local end excess energy produced by photovoltaic energy sources. For doing so, AquaMQTT provides additional operation modes to turn on either heat pump and/or heat element to reach the maximum water temperature. These operation modes can be enabled using two flags which are signaled via [MQTT](./MQTT.md). 

 [Further-Reading](./README-PV.md)

##  New control abilities introduced with this PR:

- Enable or Disable Flag PV Mode Heat Pump
`$prefix/aquamqtt/ctrl/flagPVModeHeatPump `

- Enable or Disable Flag PV Mode Heat Element
`$prefix/aquamqtt/ctrl/flagPVModeHeatElement`

- Disable or Enable Heating Element
`$prefix/aquamqtt/ctrl/heatingElementEnabled`

- Disable or Enable Emergency Mode
`$prefix/aquamqtt/ctrl/emergencyModeEnabled`

- Change OperationType e.g. Time-Window or Always On
`$prefix/aquamqtt/ctrl/operationType`

- Change Installation Config
`$prefix/aquamqtt/ctrl/configInstallation`

