### PR TITLE
feat(aquamqtt): parse and provide water production attribute

### DIFF
--- a/.idea/AquaMQTT.iml
+++ b/.idea/AquaMQTT.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="CPP_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/AquaMQTT/include/message/MainEnergyMessage.h
+++ b/AquaMQTT/include/message/MainEnergyMessage.h
@@ -28,7 +28,7 @@ public:
 
     uint16_t powerOverall();
 
-    uint16_t totalWaterConsumption();
+    uint16_t totalWaterProduction();
 
     void compareWith(uint8_t* data);
 
@@ -46,7 +46,7 @@ public:
 
     bool powerOverallChanged() const;
 
-    bool totalWaterConsumptionChanged() const;
+    bool totalWaterProductionChanged() const;
 
 private:
     uint8_t* mData;
@@ -58,7 +58,7 @@ private:
     bool mTotalHeatElementHoursChanged;
     bool mTotalHoursChanged;
     bool mTotalEnergyChanged;
-    bool mTotalWaterConsumptionChanged;
+    bool mTotalWaterProductionChanged;
 };
 
 }  // namespace message

--- a/AquaMQTT/include/message/MainEnergyMessage.h
+++ b/AquaMQTT/include/message/MainEnergyMessage.h
@@ -28,6 +28,8 @@ public:
 
     uint16_t powerOverall();
 
+    uint16_t totalWaterConsumption();
+
     void compareWith(uint8_t* data);
 
     bool totalHeatpumpHoursChanged() const;
@@ -44,6 +46,8 @@ public:
 
     bool powerOverallChanged() const;
 
+    bool totalWaterConsumptionChanged() const;
+
 private:
     uint8_t* mData;
 
@@ -54,6 +58,7 @@ private:
     bool mTotalHeatElementHoursChanged;
     bool mTotalHoursChanged;
     bool mTotalEnergyChanged;
+    bool mTotalWaterConsumptionChanged;
 };
 
 }  // namespace message

--- a/AquaMQTT/include/mqtt/MQTTDefinitions.h
+++ b/AquaMQTT/include/mqtt/MQTTDefinitions.h
@@ -120,7 +120,7 @@ constexpr char ENERGY_TOTAL_ENERGY_WH[]          = { "totalEnergyWh" };
 constexpr char ENERGY_POWER_TOTAL[]              = { "powerTotal" };
 constexpr char ENERGY_POWER_HEAT_ELEMENT[]       = { "powerHeatingElem" };
 constexpr char ENERGY_POWER_HEATPUMP[]           = { "powerHeatpump" };
-constexpr char ENERGY_TOTAL_WATER_CONSUMPTION[]  = { "waterConsumption" };
+constexpr char ENERGY_TOTAL_WATER_PRODUCTION[]   = { "totalWaterProduction" };
 
 constexpr char ERROR_ERROR_NUMBER[] = { "errorNumber" };
 

--- a/AquaMQTT/include/mqtt/MQTTDefinitions.h
+++ b/AquaMQTT/include/mqtt/MQTTDefinitions.h
@@ -120,6 +120,7 @@ constexpr char ENERGY_TOTAL_ENERGY_WH[]          = { "totalEnergyWh" };
 constexpr char ENERGY_POWER_TOTAL[]              = { "powerTotal" };
 constexpr char ENERGY_POWER_HEAT_ELEMENT[]       = { "powerHeatingElem" };
 constexpr char ENERGY_POWER_HEATPUMP[]           = { "powerHeatpump" };
+constexpr char ENERGY_TOTAL_WATER_CONSUMPTION[]  = { "waterConsumption" };
 
 constexpr char ERROR_ERROR_NUMBER[] = { "errorNumber" };
 

--- a/AquaMQTT/platformio.ini
+++ b/AquaMQTT/platformio.ini
@@ -24,8 +24,8 @@ framework = arduino
 test_framework = googletest
 build_flags = -std=c++11
 # uncomment the below lines to use over the air update
-upload_protocol = espota
-upload_port = 192.168.188.62
+#upload_protocol = espota
+#upload_port = 192.168.188.62
 lib_deps =
     locoduino/RingBuffer
     FrankBoesing/FastCRC

--- a/AquaMQTT/platformio.ini
+++ b/AquaMQTT/platformio.ini
@@ -24,8 +24,8 @@ framework = arduino
 test_framework = googletest
 build_flags = -std=c++11
 # uncomment the below lines to use over the air update
-#upload_protocol = espota
-#upload_port = 192.168.188.62
+upload_protocol = espota
+upload_port = 192.168.188.62
 lib_deps =
     locoduino/RingBuffer
     FrankBoesing/FastCRC

--- a/AquaMQTT/src/message/MainEnergyMessage.cpp
+++ b/AquaMQTT/src/message/MainEnergyMessage.cpp
@@ -40,6 +40,12 @@ uint16_t MainEnergyMessage::powerOverall()
 {
     return ((uint16_t) mData[8] << 8) | (uint16_t) mData[7];
 }
+
+uint16_t MainEnergyMessage::totalWaterConsumption()
+{
+    return ((uint16_t) mData[10] << 8) | (uint16_t) mData[9];
+}
+
 void MainEnergyMessage::compareWith(uint8_t* data)
 {
     if (data == nullptr)
@@ -51,6 +57,7 @@ void MainEnergyMessage::compareWith(uint8_t* data)
         mTotalHeatElementHoursChanged = true;
         mTotalHoursChanged            = true;
         mTotalEnergyChanged           = true;
+        mTotalWaterConsumptionChanged = true;
         return;
     }
 
@@ -75,6 +82,10 @@ void MainEnergyMessage::compareWith(uint8_t* data)
             case 7:
             case 8:
                 mPowerOverallChanged = true;
+                break;
+            case 9:
+            case 10:
+                mTotalWaterConsumptionChanged = true;
                 break;
             case 11:
             case 12:
@@ -118,6 +129,7 @@ MainEnergyMessage::MainEnergyMessage(uint8_t* data)
     , mTotalHeatElementHoursChanged(false)
     , mTotalHoursChanged(false)
     , mTotalEnergyChanged(false)
+    , mTotalWaterConsumptionChanged(false)
 {
 }
 bool MainEnergyMessage::totalHeatpumpHoursChanged() const
@@ -147,6 +159,10 @@ bool MainEnergyMessage::powerHeatElementChanged() const
 bool MainEnergyMessage::powerOverallChanged() const
 {
     return mPowerOverallChanged;
+}
+bool MainEnergyMessage::totalWaterConsumptionChanged() const
+{
+    return mTotalWaterConsumptionChanged;
 }
 
 }  // namespace message

--- a/AquaMQTT/src/message/MainEnergyMessage.cpp
+++ b/AquaMQTT/src/message/MainEnergyMessage.cpp
@@ -41,7 +41,7 @@ uint16_t MainEnergyMessage::powerOverall()
     return ((uint16_t) mData[8] << 8) | (uint16_t) mData[7];
 }
 
-uint16_t MainEnergyMessage::totalWaterConsumption()
+uint16_t MainEnergyMessage::totalWaterProduction()
 {
     return ((uint16_t) mData[10] << 8) | (uint16_t) mData[9];
 }
@@ -57,7 +57,7 @@ void MainEnergyMessage::compareWith(uint8_t* data)
         mTotalHeatElementHoursChanged = true;
         mTotalHoursChanged            = true;
         mTotalEnergyChanged           = true;
-        mTotalWaterConsumptionChanged = true;
+        mTotalWaterProductionChanged  = true;
         return;
     }
 
@@ -85,7 +85,7 @@ void MainEnergyMessage::compareWith(uint8_t* data)
                 break;
             case 9:
             case 10:
-                mTotalWaterConsumptionChanged = true;
+                mTotalWaterProductionChanged = true;
                 break;
             case 11:
             case 12:
@@ -129,7 +129,7 @@ MainEnergyMessage::MainEnergyMessage(uint8_t* data)
     , mTotalHeatElementHoursChanged(false)
     , mTotalHoursChanged(false)
     , mTotalEnergyChanged(false)
-    , mTotalWaterConsumptionChanged(false)
+    , mTotalWaterProductionChanged(false)
 {
 }
 bool MainEnergyMessage::totalHeatpumpHoursChanged() const
@@ -160,9 +160,9 @@ bool MainEnergyMessage::powerOverallChanged() const
 {
     return mPowerOverallChanged;
 }
-bool MainEnergyMessage::totalWaterConsumptionChanged() const
+bool MainEnergyMessage::totalWaterProductionChanged() const
 {
-    return mTotalWaterConsumptionChanged;
+    return mTotalWaterProductionChanged;
 }
 
 }  // namespace message

--- a/AquaMQTT/src/task/MQTTTask.cpp
+++ b/AquaMQTT/src/task/MQTTTask.cpp
@@ -760,8 +760,8 @@ void                     MQTTTask::updateEnergyStats(bool fullUpdate)
         publishul(ENERGY_SUBTOPIC, ENERGY_POWER_TOTAL, message.powerOverall());
     }
 
-    if(message.totalWaterConsumptionChanged()) {
-        publishul(ENERGY_SUBTOPIC, ENERGY_TOTAL_WATER_CONSUMPTION, message.totalWaterConsumption());
+    if(message.totalWaterProductionChanged()) {
+        publishul(ENERGY_SUBTOPIC, ENERGY_TOTAL_WATER_PRODUCTION, message.totalWaterProduction());
     }
 
     if (config::DEBUG_RAW_SERIAL_MESSAGES)

--- a/AquaMQTT/src/task/MQTTTask.cpp
+++ b/AquaMQTT/src/task/MQTTTask.cpp
@@ -760,6 +760,10 @@ void                     MQTTTask::updateEnergyStats(bool fullUpdate)
         publishul(ENERGY_SUBTOPIC, ENERGY_POWER_TOTAL, message.powerOverall());
     }
 
+    if(message.totalWaterConsumptionChanged()) {
+        publishul(ENERGY_SUBTOPIC, ENERGY_TOTAL_WATER_CONSUMPTION, message.totalWaterConsumption());
+    }
+
     if (config::DEBUG_RAW_SERIAL_MESSAGES)
     {
         sprintf(reinterpret_cast<char*>(mTopicBuffer),

--- a/MQTT.md
+++ b/MQTT.md
@@ -93,7 +93,7 @@ Using the prefix, the `$root` topic is created, which is `$prefix/aquamqtt/` and
 | Total Heating Element Hours   | `$root/energy/totalHeatingElemHours` | uint32 | h    | retained                                                                                           |
 | Total Hours                   | `$root/energy/totalHours`            | uint32 | h    | retained                                                                                           |
 | Total Energy                  | `$root/energy/totalEnergyWh`         | uint64 | Wh   |                                                                                                    |
-| Total Water Consumption       | `$root/energy/waterConsumption`      | uint16 | l    | Note: Expected to wrap-around at UINT16_MAX                                                        |
+| Total Water Production        | `$root/energy/totalWaterProduction`  | uint16 | l    | Note: Expected to wrap-around at UINT16_MAX                                                        |
 | Current Power Heatpump        | `$root/energy/powerHeatpump`         | uint16 | W    | Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h` |
 | Current Power Heating Element | `$root/energy/powerHeatingElem`      | uint16 | W    | Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h` |
 | Current Power Total           | `$root/energy/powerTotal`            | uint16 | W    |                                                                                                    |

--- a/MQTT.md
+++ b/MQTT.md
@@ -87,16 +87,17 @@ Using the prefix, the `$root` topic is created, which is `$prefix/aquamqtt/` and
 
 ### Energy Message
 
-| Value                         | MQTT Topic                           | Format | Unit | Other Information                                                                                          |
-|-------------------------------|--------------------------------------|--------|------|------------------------------------------------------------------------------------------------------------|
-| Total Heatpump Hours          | `$root/energy/totalHeatpumpHours`    | uint32 | h    | retained                                                                                                   |
-| Total Heating Element Hours   | `$root/energy/totalHeatingElemHours` | uint32 | h    | retained                                                                                                   |
-| Total Hours                   | `$root/energy/totalHours`            | uint32 | h    | retained                                                                                                   |
-| Total Energy                  | `$root/energy/totalEnergyWh`         | uint64 | Wh   |                                                                                                            |
+| Value                         | MQTT Topic                           | Format | Unit | Other Information                                                                                  |
+|-------------------------------|--------------------------------------|--------|------|----------------------------------------------------------------------------------------------------|
+| Total Heatpump Hours          | `$root/energy/totalHeatpumpHours`    | uint32 | h    | retained                                                                                           |
+| Total Heating Element Hours   | `$root/energy/totalHeatingElemHours` | uint32 | h    | retained                                                                                           |
+| Total Hours                   | `$root/energy/totalHours`            | uint32 | h    | retained                                                                                           |
+| Total Energy                  | `$root/energy/totalEnergyWh`         | uint64 | Wh   |                                                                                                    |
+| Total Water Consumption       | `$root/energy/waterConsumption`      | uint16 | l    | Note: Expected to wrap-around at UINT16_MAX                                                        |
 | Current Power Heatpump        | `$root/energy/powerHeatpump`         | uint16 | W    | Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h` |
 | Current Power Heating Element | `$root/energy/powerHeatingElem`      | uint16 | W    | Note: It is possible to define an additional custom mqtt topic for this attribute within `Configuration.h` |
-| Current Power Total           | `$root/energy/powerTotal`            | uint16 | W    |                                                                                                            |
-| Raw Message (Debug Mode Only) | `$root/energy/debug`                 | string |      |                                                                                                            |
+| Current Power Total           | `$root/energy/powerTotal`            | uint16 | W    |                                                                                                    |
+| Raw Message (Debug Mode Only) | `$root/energy/debug`                 | string |      |                                                                                                    |
 
 ### Error Messages
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -488,7 +488,7 @@ Findings...
 | 5           | 0                   | ?                                       | -                 |
 | 6           | 0                   | ?                                       | -                 |
 | 7 - 8       | 221 1               | Power Consumption Total (Both)          | -                 |
-| 9 - 10      | 54 215              | Total Water Consumption (l)             | [Ticket](https://github.com/tspopp/AquaMQTT/issues/30)            |
+| 9 - 10      | 54 215              | Total Water Production (l)              | [Ticket](https://github.com/tspopp/AquaMQTT/issues/30)     |
 | 11 - 14     | 231 9 0 0           | Total Operation Hours (Heatpump)        | -                 |
 | 15 - 18     | 24 0 0 0            | Total Operation Hours (Heating Element) | -                 |
 | 19 - 22     | 231 9 0 0           | Total Operation Hours (Both)            | -                 |

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -488,8 +488,7 @@ Findings...
 | 5           | 0                   | ?                                       | -                 |
 | 6           | 0                   | ?                                       | -                 |
 | 7 - 8       | 221 1               | Power Consumption Total (Both)          | -                 |
-| 9           | 54                  | ?                                       | -                 |
-| 10          | 215                 | ?                                       | -                 |
+| 9 - 10      | 54 215              | Total Water Consumption (l)             | [Ticket](https://github.com/tspopp/AquaMQTT/issues/30)            |
 | 11 - 14     | 231 9 0 0           | Total Operation Hours (Heatpump)        | -                 |
 | 15 - 18     | 24 0 0 0            | Total Operation Hours (Heating Element) | -                 |
 | 19 - 22     | 231 9 0 0           | Total Operation Hours (Both)            | -                 |

--- a/aquamqtt.yaml
+++ b/aquamqtt.yaml
@@ -224,6 +224,17 @@ mqtt:
         manufacturer: tspopp
         name: AquaMQTT 
         model: V1
+    - name: "Total Water Consumption"
+      state_topic: "aquamqtt/energy/waterConsumption"
+      unit_of_measurement: "l"
+      state_class: total_increasing
+      unique_id: atlantic_state_total_water_consumption
+      icon: mdi:water-pump
+      device:
+        identifiers: AquaMQTT
+        manufacturer: tspopp
+        name: AquaMQTT
+        model: V1
     - name: "Total Heating Element Hours"
       state_topic: "aquamqtt/energy/totalHeatingElemHours"
       unit_of_measurement: "h"

--- a/aquamqtt.yaml
+++ b/aquamqtt.yaml
@@ -224,11 +224,11 @@ mqtt:
         manufacturer: tspopp
         name: AquaMQTT 
         model: V1
-    - name: "Total Water Consumption"
-      state_topic: "aquamqtt/energy/waterConsumption"
+    - name: "Total Water Production"
+      state_topic: "aquamqtt/energy/totalWaterProduction"
       unit_of_measurement: "l"
       state_class: total_increasing
-      unique_id: atlantic_state_total_water_consumption
+      unique_id: atlantic_state_total_water_production
       icon: mdi:water-pump
       device:
         identifiers: AquaMQTT


### PR DESCRIPTION
- Found during discussion of water consumption #30
- Adds a new mqtt topic `energy/totalWaterProduction` which provides the water production in litres. This value is expected to wrap around uint16 max.
- Extends HomeAssistant default configuration originally provided from @scoudibou 

Thanks @kopierschnitte for bringing up the issue, testing and proofing AquaMQTT values against the Cozytouch values 🙌 👍 