### PR TITLE
fix(wifi): do not trust platform auto reconnect routines

### DIFF
--- a/AquaMQTT/include/config/Configuration.h
+++ b/AquaMQTT/include/config/Configuration.h
@@ -44,7 +44,6 @@ constexpr EOperationMode OPERATION_MODE = EOperationMode::MITM;
  */
 constexpr bool OVERRIDE_TIME_AND_DATE_IN_MITM = true;
 
-
 /**
  * Choose to publish raw messages represented as hex-string on debug mqtt topics
  */
@@ -53,19 +52,20 @@ constexpr bool DEBUG_RAW_SERIAL_MESSAGES = false;
 /**
  * Change the time interval where all known attributes are re-published to the MQTT broker.
  */
-constexpr uint32_t MQTT_FULL_UPDATE_MS = 1000*60*30;
+constexpr uint32_t MQTT_FULL_UPDATE_MS = 1000 * 60 * 30;
 
 /**
  * Change the fixed time interval where the attributes published to the stats topic are updated.
  */
-constexpr uint16_t MQTT_STATS_UPDATE_MS  = 5000;
+constexpr uint16_t MQTT_STATS_UPDATE_MS = 5000;
 
 /**
  * Self explanatory internal settings: most probably you don't want to change them.
  */
-constexpr uint8_t  WATCHDOG_TIMEOUT_S    = 60;
-constexpr uint8_t  MQTT_MAX_TOPIC_SIZE   = 80;
-constexpr uint8_t  MQTT_MAX_PAYLOAD_SIZE = 255;
+constexpr uint8_t  WATCHDOG_TIMEOUT_S     = 60;
+constexpr uint16_t WIFI_RECONNECT_CYCLE_S = 10;
+constexpr uint8_t  MQTT_MAX_TOPIC_SIZE    = 80;
+constexpr uint8_t  MQTT_MAX_PAYLOAD_SIZE  = 255;
 
 /**
  * Pin assignments for AquaMQTT Board Rev 1.0

--- a/AquaMQTT/include/handler/Wifi.h
+++ b/AquaMQTT/include/handler/Wifi.h
@@ -1,0 +1,32 @@
+#ifndef AQUAMQTT_WIFI_H
+#define AQUAMQTT_WIFI_H
+
+#include <WiFi.h>
+
+namespace aquamqtt
+{
+class WifiHandler
+{
+public:
+    WifiHandler();
+
+    virtual ~WifiHandler() = default;
+
+    void setup();
+
+    void loop();
+
+private:
+    static void wifiCallback(WiFiEvent_t event);
+
+    unsigned long mLastCheck;
+
+    static bool mConnectedToWifiWithValidIpAddress;
+
+};
+
+}  // namespace aquamqtt
+
+
+
+#endif  // AQUAMQTT_WIFI_H

--- a/AquaMQTT/src/handler/Wifi.cpp
+++ b/AquaMQTT/src/handler/Wifi.cpp
@@ -1,0 +1,71 @@
+#include "handler/Wifi.h"
+
+#include "config/Configuration.h"
+
+namespace aquamqtt
+{
+
+bool WifiHandler::mConnectedToWifiWithValidIpAddress = false;
+
+WifiHandler::WifiHandler() : mLastCheck(0)
+{
+}
+
+void WifiHandler::setup()
+{
+    WiFiClass::mode(WIFI_STA);
+
+    // we don't trust the auto reconnect routine, as it seems there are edge cases where it does not work
+    WiFi.setAutoReconnect(false);
+
+    // we trust the wifi callbacks to determine if we are properly connected or disconnected
+    WiFi.onEvent(wifiCallback);
+
+    // begin a single wifi session
+    WiFi.begin(aquamqtt::config::ssid, aquamqtt::config::psk);
+
+    // perform the next wifi check in config::WIFI_RECONNECT_CYCLE_S
+    mLastCheck = millis();
+}
+
+void WifiHandler::loop()
+{
+    if ((millis() - mLastCheck) >= (config::WIFI_RECONNECT_CYCLE_S * 1000))
+    {
+        mLastCheck = millis();
+
+        // we don't trust WiFi.isConnected() or WiFi.status() == WL_CONNECTED, since it is suspected to be unreliable
+        if (!mConnectedToWifiWithValidIpAddress)
+        {
+            Serial.println("[wifi] attempting reconnect");
+            WiFi.disconnect();
+            WiFi.reconnect();
+        }
+    }
+}
+
+void WifiHandler::wifiCallback(WiFiEvent_t event)
+{
+    Serial.print("[wifi] event: ");
+    Serial.println(WiFi.eventName(event));
+
+    switch (event)
+    {
+        case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
+        case ARDUINO_EVENT_WIFI_STA_LOST_IP:
+            // if we lost connection or ip address, we wil enforce a reconnect within the next cycle
+            mConnectedToWifiWithValidIpAddress = false;
+            break;
+        case ARDUINO_EVENT_WIFI_STA_GOT_IP:
+        case ARDUINO_EVENT_WIFI_STA_GOT_IP6:
+            // if we got connection and therefore a valid ip address we have a valid connection
+            Serial.print("[wifi] ip address: ");
+            Serial.println(WiFi.localIP().toString().c_str());
+            mConnectedToWifiWithValidIpAddress = true;
+            break;
+        default:
+            break;
+    }
+}
+
+}  // namespace aquamqtt


### PR DESCRIPTION
Periodically checking if the WiFi is good instead of trusting the platform auto reconnect routines, since there are edge cases where it seems to fail. Resolves #26 
