### PR TITLE
Introduce Timed Intervals for MQTT Messages

### DIFF
--- a/AquaMQTT/include/config/Configuration.h
+++ b/AquaMQTT/include/config/Configuration.h
@@ -55,9 +55,24 @@ constexpr bool DEBUG_RAW_SERIAL_MESSAGES = false;
 constexpr uint32_t MQTT_FULL_UPDATE_MS = 1000 * 60 * 30;
 
 /**
- * Change the fixed time interval where the attributes published to the stats topic are updated.
+ * Change the time interval where the attributes published to the 'energy' topic are updated.
  */
-constexpr uint16_t MQTT_STATS_UPDATE_MS = 5000;
+constexpr uint32_t MQTT_ENERGY_UPDATE_MS = 1000 * 60;
+
+/**
+ * Change the time interval where the attributes published to the 'hmi' topic are updated.
+ */
+constexpr uint32_t MQTT_HMI_UPDATE_MS = 1000 * 60;
+
+/**
+ * Change the time interval where the attributes published to the 'main' topic are updated.
+ */
+constexpr uint32_t MQTT_MAIN_UPDATE_MS = 1000 * 60;
+
+/**
+ * Change the time interval where the attributes published to the 'stats' topic are updated.
+ */
+constexpr uint32_t MQTT_STATS_UPDATE_MS = 1000 * 60 * 5;
 
 /**
  * Self explanatory internal settings: most probably you don't want to change them.

--- a/AquaMQTT/include/task/MQTTTask.h
+++ b/AquaMQTT/include/task/MQTTTask.h
@@ -42,6 +42,9 @@ private:
     uint8_t       mTransferBuffer[message::HEATPUMP_MAX_FRAME_LENGTH];
     uint8_t       mTopicBuffer[config::MQTT_MAX_TOPIC_SIZE];
     uint8_t       mPayloadBuffer[config::MQTT_MAX_PAYLOAD_SIZE];
+    unsigned long mLastEnergyUpdate;
+    unsigned long mLastHmiUpdate;
+    unsigned long mLastMainUpdate;
     unsigned long mLastStatsUpdate;
     unsigned long mLastFullUpdate;
     WiFiClient    mWiFiClient;


### PR DESCRIPTION
This PR introduces timers for all MQTT topics (Energy, Main, HMI, and Stats), ensuring data is sent only at the configured intervals rather than immediately after a value change (e.g., water temperature).

Full updates and Error updates remain unaffected: Full updates are already configurable, and Error messages should still be relayed ASAP for critical notifications.

I initiated this change because my Atlantic Explorer V4 was sending temperature values approximately every 0.5 seconds, which overwhelmed the Home Assistant recorder. Since AquaMQTT controls heat pumps, real-time temperature data isn’t essential. Configurable intervals, such as 1 or 5 minutes, provide a more practical solution.