### PR TITLE
Add water_heater integration

### DIFF
--- a/aquamqtt.yaml
+++ b/aquamqtt.yaml
@@ -397,9 +397,18 @@ mqtt:
         manufacturer: tspopp
         name: AquaMQTT 
         model: V1
+  
+  water_heater:
+    - name: "AquaMQTT boiler"
+      icon: mdi:water-boiler
+      temperature_state_topic: "aquamqtt/hmi/waterTempTarget"
+      temperature_command_topic: "aquamqtt/ctrl/waterTempTarget"
+      current_temperature_topic: "aquamqtt/main/waterTemp"
+      unique_id: atlantic_water_boiler_thermostat
+      precision: 0.5
+   
   button:
     - name: "Reset Overrides"
-
       command_topic: "aquamqtt/ctrl/reset"
       payload_press: ""
       qos: 0

--- a/aquamqtt.yaml
+++ b/aquamqtt.yaml
@@ -401,12 +401,19 @@ mqtt:
   water_heater:
     - name: "AquaMQTT boiler"
       icon: mdi:water-boiler
+      modes:
+      - "ABSENCE"
+      - "AUTO"
+      - "BOOST"
+      - "MAN ECO OFF"
+      - "MAN ECO ON"
+      mode_state_topic: "aquamqtt/hmi/operationMode"
+      mode_command_topic: "aquamqtt/ctrl/operationMode"
       temperature_state_topic: "aquamqtt/hmi/waterTempTarget"
       temperature_command_topic: "aquamqtt/ctrl/waterTempTarget"
       current_temperature_topic: "aquamqtt/main/waterTemp"
       unique_id: atlantic_water_boiler_thermostat
-      precision: 0.5
-   
+      precision: 1.0
   button:
     - name: "Reset Overrides"
       command_topic: "aquamqtt/ctrl/reset"


### PR DESCRIPTION
See https://www.home-assistant.io/integrations/water_heater.mqtt/ for integration details

example:
![image](https://github.com/user-attachments/assets/76668c11-511e-4b73-b5b8-e48c72a7890c)

optionally, we can set the (or some) operation modes:
      modes:
        - "ABSENCE"
        - "MAN ECO ON"
      mode_state_topic: "aquamqtt/hmi/operationMode"
      mode_command_topic: "aquamqtt/ctrl/operationMode"

and intervals of 0.5 might be too small and can be increased to 1
