### PR TITLE
feat(mqtt): configuration options to disable several debugging mqtt topics

### DIFF
--- a/AquaMQTT/include/config/Configuration.h
+++ b/AquaMQTT/include/config/Configuration.h
@@ -61,6 +61,22 @@ constexpr bool OVERRIDE_TIME_AND_DATE_IN_MITM = true;
 constexpr bool DEBUG_RAW_SERIAL_MESSAGES = false;
 
 /**
+ * Choose to publish message statistics from the serial interfaces, if everything
+ * works as it should you may disable this. If set to true, this will provide the
+ * topics "msgHandled, msgUnhandled, msgCRCNOK and msgSent" topics for each serial
+ * channel (hmi/main or listener),
+ */
+constexpr bool MQTT_PUBLISH_SERIAL_STATISTICS = false;
+
+/**
+ * Choose to publish time and date used by the heatpump. This is mainly for debugging
+ * if the time and date override from AquaMQTT works as expected. You may want to
+ * enable this, if you are customizing the NTP timezone or server or even trying to
+ * use the RTC module from the AquaMQTT board.
+ */
+constexpr bool MQTT_PUBLISH_HEATPUMP_TIME_AND_DATE = false;
+
+/**
  * Change the time interval where all known attributes are re-published to the MQTT broker.
  */
 constexpr uint32_t MQTT_FULL_UPDATE_MS = 1000 * 60 * 30;

--- a/AquaMQTT/include/config/Configuration.h
+++ b/AquaMQTT/include/config/Configuration.h
@@ -66,7 +66,7 @@ constexpr bool DEBUG_RAW_SERIAL_MESSAGES = false;
  * topics "msgHandled, msgUnhandled, msgCRCNOK and msgSent" topics for each serial
  * channel (hmi/main or listener),
  */
-constexpr bool MQTT_PUBLISH_SERIAL_STATISTICS = false;
+constexpr bool MQTT_PUBLISH_SERIAL_STATISTICS = true;
 
 /**
  * Choose to publish time and date used by the heatpump. This is mainly for debugging

--- a/AquaMQTT/include/mqtt/MQTTDiscovery.h
+++ b/AquaMQTT/include/mqtt/MQTTDiscovery.h
@@ -295,7 +295,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["uniq_id"]      = make_unique(temp, identifier, "energy_total_wp");
             break;
         case MQTT_ITEM_SENSOR::STATS_HMI_MSG_HANDLED:
-            if (config::OPERATION_MODE != config::EOperationMode::MITM)
+            if (config::OPERATION_MODE != config::EOperationMode::MITM || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -306,7 +306,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::STATS_HMI_MSG_UNHANDLED:
-            if (config::OPERATION_MODE != config::EOperationMode::MITM)
+            if (config::OPERATION_MODE != config::EOperationMode::MITM || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -317,7 +317,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::STATS_HMI_MSG_SENT:
-            if (config::OPERATION_MODE != config::EOperationMode::MITM)
+            if (config::OPERATION_MODE != config::EOperationMode::MITM || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -328,7 +328,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::STATS_HMI_MSG_CRC_NOK:
-            if (config::OPERATION_MODE != config::EOperationMode::MITM)
+            if (config::OPERATION_MODE != config::EOperationMode::MITM || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -339,7 +339,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::STATS_HMI_DROPPED_BYTES:
-            if (config::OPERATION_MODE != config::EOperationMode::MITM)
+            if (config::OPERATION_MODE != config::EOperationMode::MITM || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -350,7 +350,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::STATS_MAIN_MSG_HANDLED:
-            if (config::OPERATION_MODE != config::EOperationMode::MITM)
+            if (config::OPERATION_MODE != config::EOperationMode::MITM || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -361,7 +361,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::STATS_MAIN_MSG_UNHANDLED:
-            if (config::OPERATION_MODE != config::EOperationMode::MITM)
+            if (config::OPERATION_MODE != config::EOperationMode::MITM || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -372,7 +372,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::STATS_MAIN_MSG_SENT:
-            if (config::OPERATION_MODE != config::EOperationMode::MITM)
+            if (config::OPERATION_MODE != config::EOperationMode::MITM || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -383,7 +383,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::STATS_MAIN_MSG_CRC_NOK:
-            if (config::OPERATION_MODE != config::EOperationMode::MITM)
+            if (config::OPERATION_MODE != config::EOperationMode::MITM || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -394,7 +394,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::STATS_MAIN_DROPPED_BYTES:
-            if (config::OPERATION_MODE != config::EOperationMode::MITM)
+            if (config::OPERATION_MODE != config::EOperationMode::MITM || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -405,7 +405,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::STATS_LST_MSG_HANDLED:
-            if (config::OPERATION_MODE != config::EOperationMode::LISTENER)
+            if (config::OPERATION_MODE != config::EOperationMode::LISTENER || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -416,7 +416,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::STATS_LST_MSG_UNHANDLED:
-            if (config::OPERATION_MODE != config::EOperationMode::LISTENER)
+            if (config::OPERATION_MODE != config::EOperationMode::LISTENER || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -427,7 +427,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::STATS_LST_MSG_CRC_NOK:
-            if (config::OPERATION_MODE != config::EOperationMode::LISTENER)
+            if (config::OPERATION_MODE != config::EOperationMode::LISTENER || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -438,7 +438,7 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::STATS_LST_DROPPED_BYTES:
-            if (config::OPERATION_MODE != config::EOperationMode::LISTENER)
+            if (config::OPERATION_MODE != config::EOperationMode::LISTENER || !config::MQTT_PUBLISH_SERIAL_STATISTICS)
             {
                 return false;
             }
@@ -449,6 +449,10 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::HMI_TIME:
+            if (!config::MQTT_PUBLISH_HEATPUMP_TIME_AND_DATE)
+            {
+                return false;
+            }
             doc["name"]    = "Time";
             doc["stat_t"]  = "~/hmi/time";
             doc["uniq_id"] = make_unique(temp, identifier, "hmi_time");
@@ -456,6 +460,10 @@ static bool buildConfiguration(uint8_t* buffer, uint16_t identifier, MQTT_ITEM_S
             doc["ent_cat"] = "diagnostic";
             break;
         case MQTT_ITEM_SENSOR::HMI_DATE:
+            if (!config::MQTT_PUBLISH_HEATPUMP_TIME_AND_DATE)
+            {
+                return false;
+            }
             doc["name"]    = "Date";
             doc["stat_t"]  = "~/hmi/date";
             doc["uniq_id"] = make_unique(temp, identifier, "hmi_date");

--- a/AquaMQTT/src/task/MQTTTask.cpp
+++ b/AquaMQTT/src/task/MQTTTask.cpp
@@ -429,28 +429,35 @@ void MQTTTask::updateStats()
 
     if (config::OPERATION_MODE == config::EOperationMode::LISTENER)
     {
-        auto listenerStats = DHWState::getInstance().getFrameBufferStatistics(0);
-        publishul(STATS_SUBTOPIC, STATS_MSG_HANDLED, listenerStats.msgHandled);
-        publishul(STATS_SUBTOPIC, STATS_MSG_UNHANDLED, listenerStats.msgUnhandled);
-        publishul(STATS_SUBTOPIC, STATS_MSG_CRC_NOK, listenerStats.msgCRCFail);
-        publishul(STATS_SUBTOPIC, STATS_DROPPED_BYTES, listenerStats.droppedBytes);
+        if (config::MQTT_PUBLISH_SERIAL_STATISTICS)
+        {
+            auto listenerStats = DHWState::getInstance().getFrameBufferStatistics(0);
+            publishul(STATS_SUBTOPIC, STATS_MSG_HANDLED, listenerStats.msgHandled);
+            publishul(STATS_SUBTOPIC, STATS_MSG_UNHANDLED, listenerStats.msgUnhandled);
+            publishul(STATS_SUBTOPIC, STATS_MSG_CRC_NOK, listenerStats.msgCRCFail);
+            publishul(STATS_SUBTOPIC, STATS_DROPPED_BYTES, listenerStats.droppedBytes);
+        }
     }
     else
     {
-        auto hmiStats = DHWState::getInstance().getFrameBufferStatistics(1);
-        publishul(STATS_SUBTOPIC, HMI_SUBTOPIC, STATS_MSG_HANDLED, hmiStats.msgHandled);
-        publishul(STATS_SUBTOPIC, HMI_SUBTOPIC, STATS_MSG_UNHANDLED, hmiStats.msgUnhandled);
-        publishul(STATS_SUBTOPIC, HMI_SUBTOPIC, STATS_MSG_CRC_NOK, hmiStats.msgCRCFail);
-        publishul(STATS_SUBTOPIC, HMI_SUBTOPIC, STATS_DROPPED_BYTES, hmiStats.droppedBytes);
-        publishul(STATS_SUBTOPIC, HMI_SUBTOPIC, STATS_MSG_SENT, hmiStats.msgSent);
+        if (config::MQTT_PUBLISH_SERIAL_STATISTICS)
+        {
+            auto hmiStats = DHWState::getInstance().getFrameBufferStatistics(1);
+            publishul(STATS_SUBTOPIC, HMI_SUBTOPIC, STATS_MSG_HANDLED, hmiStats.msgHandled);
+            publishul(STATS_SUBTOPIC, HMI_SUBTOPIC, STATS_MSG_UNHANDLED, hmiStats.msgUnhandled);
+            publishul(STATS_SUBTOPIC, HMI_SUBTOPIC, STATS_MSG_CRC_NOK, hmiStats.msgCRCFail);
+            publishul(STATS_SUBTOPIC, HMI_SUBTOPIC, STATS_DROPPED_BYTES, hmiStats.droppedBytes);
+            publishul(STATS_SUBTOPIC, HMI_SUBTOPIC, STATS_MSG_SENT, hmiStats.msgSent);
 
-        auto mainStats = DHWState::getInstance().getFrameBufferStatistics(2);
-        publishul(STATS_SUBTOPIC, MAIN_SUBTOPIC, STATS_MSG_HANDLED, mainStats.msgHandled);
-        publishul(STATS_SUBTOPIC, MAIN_SUBTOPIC, STATS_MSG_UNHANDLED, mainStats.msgUnhandled);
-        publishul(STATS_SUBTOPIC, MAIN_SUBTOPIC, STATS_MSG_CRC_NOK, mainStats.msgCRCFail);
-        publishul(STATS_SUBTOPIC, MAIN_SUBTOPIC, STATS_DROPPED_BYTES, mainStats.droppedBytes);
-        publishul(STATS_SUBTOPIC, MAIN_SUBTOPIC, STATS_MSG_SENT, mainStats.msgSent);
+            auto mainStats = DHWState::getInstance().getFrameBufferStatistics(2);
+            publishul(STATS_SUBTOPIC, MAIN_SUBTOPIC, STATS_MSG_HANDLED, mainStats.msgHandled);
+            publishul(STATS_SUBTOPIC, MAIN_SUBTOPIC, STATS_MSG_UNHANDLED, mainStats.msgUnhandled);
+            publishul(STATS_SUBTOPIC, MAIN_SUBTOPIC, STATS_MSG_CRC_NOK, mainStats.msgCRCFail);
+            publishul(STATS_SUBTOPIC, MAIN_SUBTOPIC, STATS_DROPPED_BYTES, mainStats.droppedBytes);
+            publishul(STATS_SUBTOPIC, MAIN_SUBTOPIC, STATS_MSG_SENT, mainStats.msgSent);
+        }
 
+        // TODO: these should be updated a soon as something changes, and not by the stats timer
         auto         overrides = HMIStateProxy::getInstance().getOverrides();
         JsonDocument overrideJson;
         overrideJson[HMI_OPERATION_MODE]          = overrides.operationMode ? "1" : "0";
@@ -625,7 +632,7 @@ void MQTTTask::updateHMIStatus(bool fullUpdate)
         publishString(HMI_SUBTOPIC, HMI_OPERATION_TYPE, operationTypeStr(message.getOperationType()));
     }
 
-    if (message.timeChanged())
+    if (config::MQTT_PUBLISH_HEATPUMP_TIME_AND_DATE && message.timeChanged())
     {
         sprintf(reinterpret_cast<char*>(mPayloadBuffer),
                 "%02d:%02d:%02d",
@@ -641,7 +648,7 @@ void MQTTTask::updateHMIStatus(bool fullUpdate)
         mMQTTClient.publish(reinterpret_cast<char*>(mTopicBuffer), reinterpret_cast<char*>(mPayloadBuffer));
     }
 
-    if (message.dateChanged())
+    if (config::MQTT_PUBLISH_HEATPUMP_TIME_AND_DATE && message.dateChanged())
     {
         sprintf(reinterpret_cast<char*>(mPayloadBuffer),
                 "%d.%d.%d",


### PR DESCRIPTION
- [x] option to disable time and date messages sent to mqtt
- [x] option to disable stats messages sent to mqtt

In my case I observe very limited mqtt traffic with these changes.

@henrykuijpers please check if this is good for you :) I still kept the statistics interval at 5s in the default configuration, since some of the values are not published _onChange_. This means for example you will get a change of `flagPVModeHeatPump` only every 5 seconds and not in between. I need some refactoring to fix this, but this part is currently not the cleanest...