### PR TITLE
Update configuration to reduce amount of MQTT messages by default

### DIFF
--- a/AquaMQTT/include/config/Configuration.h
+++ b/AquaMQTT/include/config/Configuration.h
@@ -67,7 +67,7 @@ constexpr bool DEBUG_RAW_SERIAL_MESSAGES = false;
  * topics "msgHandled, msgUnhandled, msgCRCNOK and msgSent" topics for each serial
  * channel (hmi/main or listener),
  */
-constexpr bool MQTT_PUBLISH_SERIAL_STATISTICS = true;
+constexpr bool MQTT_PUBLISH_SERIAL_STATISTICS = false;
 
 /**
  * Choose to publish time and date used by the heatpump. This is mainly for debugging
@@ -75,7 +75,7 @@ constexpr bool MQTT_PUBLISH_SERIAL_STATISTICS = true;
  * enable this, if you are customizing the NTP timezone or server or even trying to
  * use the RTC module from the AquaMQTT board.
  */
-constexpr bool MQTT_PUBLISH_HEATPUMP_TIME_AND_DATE = true;
+constexpr bool MQTT_PUBLISH_HEATPUMP_TIME_AND_DATE = false;
 
 /**
  * Change the time interval where all known attributes are re-published to the MQTT broker.


### PR DESCRIPTION
This resolves issues with specifically new users that are getting unexpected results due to a flood of update messages, for example: https://github.com/tspopp/AquaMQTT/pull/37#issuecomment-2649141488