### PR TITLE
fix(rtc): change mLastStateUpdate from time_t to unsigned long

### DIFF
--- a/AquaMQTT/include/handler/RTC.h
+++ b/AquaMQTT/include/handler/RTC.h
@@ -18,7 +18,7 @@ public:
 
 private:
     unsigned long mLastNTPUpdate;
-    time_t        mLastStateUpdate;
+    unsigned long mLastStateUpdate;
     bool          mFoundRTC;
     RTC_DS3231    mRTC;
 };


### PR DESCRIPTION
Fixes #92 

The mLastStateUpdate variable was declared as time_t (signed integer) while being compared with millis() return values (unsigned long). This caused incorrect behavior after millis() exceeded the maximum signed integer value (2,147,483,647ms / ~24.8 days), causing time updates to stop being sent.

Changed mLastStateUpdate to unsigned long to match the type returned by millis() and ensure proper overflow handling in time comparisons.

To reproduce and validate this bug without waiting 24.8 days, I implemented an accelerated time testing approach. I created a `getTestMillis()` helper function that adds an offset of 4,294,667,295 to the actual `millis()` value, effectively placing the system time ~5 minutes before the unsigned long overflow point (4,294,967,295). All time comparisons in the RTC handler were updated to use this accelerated time during testing. This allowed me to observe the overflow behavior within minutes rather than weeks.

Before the fix, I observed time updates working normally until the overflow occurred, at which point updates immediately stopped due to the signed/unsigned type mismatch causing the time difference calculation `(millis() - mLastStateUpdate)` to fail. After applying the fix (changing `mLastStateUpdate` to unsigned long), time updates continued seamlessly through the overflow event, confirming the fix handles the wraparound correctly. The test code included overflow detection logging to precisely identify when the overflow occurred and verify continued operation afterward.

<img width="1481" height="164" alt="image" src="https://github.com/user-attachments/assets/31c593b6-a83c-4435-8974-4c2eb5583e33" />

I've stashed this test code in case this is needed in the future.

As stated in the issue, I've used Claude to help find the bug and help with validating and fixing the bug.