### PR TITLE
feat(climate): add climate component to home-assistant discovery

### DIFF
--- a/AquaMQTT/include/Version.h
+++ b/AquaMQTT/include/Version.h
@@ -1,4 +1,4 @@
 namespace aquamqtt
 {
-constexpr char VERSION[] = "v1.8.0";
+constexpr char VERSION[] = "v1.8.1";
 }

--- a/AquaMQTT/include/config/Configuration.h
+++ b/AquaMQTT/include/config/Configuration.h
@@ -153,12 +153,21 @@ constexpr float MAX_WATER_TEMPERATURE = 62.0;
 constexpr float ABSENCE_WATER_TEMPERATURE = 20.0;
 
 /**
+*  Enable more comprehensive climate control through Home Assistant climate cards, provided by user @Gwaboo
+*  See https://github.com/tspopp/AquaMQTT/blob/main/HOMEASSISTANT.md
+*/
+constexpr bool ENABLE_HOMEASSISTANT_CLIMATE_CARD = true;
+constexpr float CLIMATE_CARD_MIN_TEMPERATURE = 43.0;
+constexpr float CLIMATE_CARD_MAX_TEMPERATURE = 61.0;
+constexpr float CLIMATE_CARD_STEP_TEMPERATURE = 1.0;
+
+/**
  * Self-explanatory internal settings: most probably you don't want to change them.
  */
 constexpr uint32_t WATCHDOG_TIMEOUT_MS    = 60000;
 constexpr uint16_t WIFI_RECONNECT_CYCLE_S = 10;
 constexpr uint16_t MQTT_MAX_TOPIC_SIZE    = 255;
-constexpr uint16_t MQTT_MAX_PAYLOAD_SIZE  = 1024;
+constexpr uint16_t MQTT_MAX_PAYLOAD_SIZE  = 1536;
 
 /**
  * Pin assignments for AquaMQTT Board Rev 1.0

--- a/AquaMQTT/src/task/MQTTTask.cpp
+++ b/AquaMQTT/src/task/MQTTTask.cpp
@@ -1728,6 +1728,8 @@ void MQTTTask::sendHomeassistantDiscovery()
     publishDiscovery(identifier, protocolVersion, "switch", discovery::MQTT_ITEM_SWITCH::RESERVED_COUNT);
     publishDiscovery(identifier, protocolVersion, "select", discovery::MQTT_ITEM_SELECT::RESERVED_COUNT);
     publishDiscovery(identifier, protocolVersion, "water_heater", discovery::MQTT_ITEM_WATER_HEATER::RESERVED_COUNT);
+    publishDiscovery(identifier, protocolVersion, "climate", discovery::MQTT_ITEM_CLIMATE::RESERVED_COUNT);
+
 
     mPublishedDiscovery = true;
 }


### PR DESCRIPTION
Adds a climate component to mqtt auto discovery, see https://github.com/tspopp/AquaMQTT/blob/main/HOMEASSISTANT.md

@Gwaboo Finally added your proposal to automatic mqtt discovery. To me, this looks good. You may want to give feedback, else I will merge this sooner or later :)

In any way, thank you very much for your contribution.