### PR TITLE
Fix buffer length

### DIFF
--- a/prototypes/CV5Listener/src/buffer/ModbusBuffer.cpp
+++ b/prototypes/CV5Listener/src/buffer/ModbusBuffer.cpp
@@ -128,7 +128,7 @@ int ModbusBuffer::handleFrame()
             {
                 sprintf(reinterpret_cast<char*>(mTopicBuffer), "%s%s%d/%d/%d/%d/%s", config::mqttPrefix,
                 mqtt::BASE_TOPIC, functionCode, parameter01, parameter02, subfn, mqtt::DEBUG);
-                toHexStr(mTransferBuffer, length, reinterpret_cast<char*>(mPayloadBuffer));
+                toHexStr(mTransferBuffer, totalLength, reinterpret_cast<char*>(mPayloadBuffer));
                 mMQTTClient->publish(reinterpret_cast<char*>(mTopicBuffer), reinterpret_cast<char*>(mPayloadBuffer));
                 mHandledCount++;
             }


### PR DESCRIPTION
I have an Explorer V5 and I gratefully used your code to monitor communication between the HMI and the MAIN unit.

It seems that the ESP32 does not publish all data to MQTT. Some example output:
```
2026-05-02 21:05:20.765695,cv5/100/254/176/6/debug,0164FEB0060C129B098008EA
2026-05-02 21:05:21.378391,cv5/100/254/176/6/debug,0164FEB0060C1298098708EC
2026-05-02 21:05:22.008634,cv5/100/254/176/6/debug,0164FEB0060C129B098708EA
2026-05-02 21:05:22.814140,cv5/100/254/176/6/debug,0164FEB0060C1298098E08EA
2026-05-02 21:05:23.325965,cv5/100/254/176/6/debug,0164FEB0060C129B099508EC
```

The length field `0x0c` indicates the payload length, which should be 12 bytes, but is in fact 6 bytes (12 hex characters).

With this PR it returns the full message size. New output example:
```
2026-05-03 13:27:49.704745,cv5/100/254/176/6/debug,0164FEB0060C135B0ACA0978088608680906
2026-05-03 13:27:50.114052,cv5/100/254/176/6/debug,0164FEB0060C135E0AD10976088808680908
2026-05-03 13:27:50.729696,cv5/100/254/176/6/debug,0164FEB0060C135E0AD10978088608680908
2026-05-03 13:27:51.358726,cv5/100/254/176/6/debug,0164FEB0060C135E0ADC097808880868090A
```

The values are (first message):
- water temperature (135B = 49.55)
- compressor outlet temperature (0ACA = 27.62)
- air inlet temperature (0978 = 24.24)
- evaporator 1 temperature (0886 = 21.82)
- evaporator 2 temperature (0868 = 21.52)
- evaporator 3 temperature (0906 = 23.10)
