### PR TITLE
Feat: Add Optitronic 2 (Modbus RTU) protocol support

### DIFF
--- a/AquaMQTT/data/config/aquamqtt.json
+++ b/AquaMQTT/data/config/aquamqtt.json
@@ -1,0 +1,4 @@
+{
+  "heatpumpModelName": "Austria Email WPA 450 ECO",
+  "operationMode": 3
+}

--- a/AquaMQTT/data/config/mqtt.json
+++ b/AquaMQTT/data/config/mqtt.json
@@ -1,0 +1,9 @@
+{
+  "server": "CHANGE_ME",
+  "port": 1883,
+  "user": "CHANGE_ME",
+  "password": "CHANGE_ME",
+  "clientId": "aquamqtt",
+  "enableDiscovery": true,
+  "discoveryPrefix": "homeassistant/"
+}

--- a/AquaMQTT/data/config/wifi.json
+++ b/AquaMQTT/data/config/wifi.json
@@ -1,0 +1,5 @@
+{
+  "ssid": "CHANGE_ME",
+  "password": "CHANGE_ME",
+  "networkName": "aquamqtt"
+}

--- a/AquaMQTT/include/config/Configuration.h
+++ b/AquaMQTT/include/config/Configuration.h
@@ -4,7 +4,7 @@
 /**
  * Possibility to include your own configuration file (added to .gitignore)
  */
-//#define CUSTOM_CONFIGURATION
+#define CUSTOM_CONFIGURATION
 
 #ifdef CUSTOM_CONFIGURATION
 #    include "CustomConfiguration.h"
@@ -47,7 +47,7 @@ constexpr char haDiscoveryPrefix[] = "homeassistant/";
 /**
  * The OperationMode which is used for AquaMqtt. Refer to EOperationMode
  */
-constexpr EOperationMode OPERATION_MODE = EOperationMode::MITM;
+constexpr EOperationMode OPERATION_MODE = EOperationMode::OPTITRONIC2_MITM;
 
 /**
  * Choose if the time and date values sent to the main controller should override the ones sent by the hmi controller.

--- a/AquaMQTT/include/config/Modes.h
+++ b/AquaMQTT/include/config/Modes.h
@@ -31,6 +31,17 @@ enum EOperationMode
      * - Compatible with: Austria Email WPA 450 ECO and similar Optitronic 2 devices
      */
     OPTITRONIC2_LISTENER,
+
+    /**
+     * Optitronic 2 Modbus RTU MITM (Man-In-The-Middle) mode:
+     * - Passthrough jumper REMOVED — ESP32 actively relays between HMI and Main
+     * - Receives frames from HMI (Serial1) and forwards to Main (Serial2)
+     * - Receives frames from Main (Serial2) and forwards to HMI (Serial1)
+     * - Parses all traffic for state extraction and MQTT publishing
+     * - Injects MQTT-commanded writes during bus idle periods
+     * - Protocol: Standard Modbus RTU, 57600 8N1, slave 0x01
+     */
+    OPTITRONIC2_MITM,
 };
 }
 

--- a/AquaMQTT/include/config/Modes.h
+++ b/AquaMQTT/include/config/Modes.h
@@ -20,6 +20,17 @@ enum EOperationMode
      * - Parses and publishes DHW messages to MQTT, Allows modification via MQTT
      */
     MITM,
+
+    /**
+     * Optitronic 2 Modbus RTU Listener mode:
+     * - Passively sniffs the Modbus RTU bus between HMI and main controller
+     * - Parses read responses and write commands to extract register values
+     * - Publishes decoded register data to MQTT with HA discovery
+     * - Accepts MQTT commands and injects Modbus writes during bus idle periods
+     * - Protocol: Standard Modbus RTU, 57600 8N1, slave 0x01
+     * - Compatible with: Austria Email WPA 450 ECO and similar Optitronic 2 devices
+     */
+    OPTITRONIC2_LISTENER,
 };
 }
 

--- a/AquaMQTT/include/config/WebConfig.h
+++ b/AquaMQTT/include/config/WebConfig.h
@@ -1,0 +1,45 @@
+#ifndef AQUAMQTT_WEBCONFIG_H
+#define AQUAMQTT_WEBCONFIG_H
+
+#include <Arduino.h>
+
+namespace aquamqtt
+{
+
+struct WifiConfig
+{
+    String ssid;
+    String password;
+    String networkName;
+};
+
+struct MqttConfig
+{
+    String server;
+    uint16_t port;
+    String user;
+    String password;
+    String clientId;
+    bool enableDiscovery;
+    String discoveryPrefix;
+};
+
+struct AquaMqttConfig
+{
+    String heatpumpModelName;
+    int operationMode;
+};
+
+// Global config instances (defined in WebConfig.cpp)
+extern WifiConfig wifiConfig;
+extern MqttConfig mqttConfig;
+extern AquaMqttConfig aquaMqttConfig;
+
+bool loadAllConfig();
+bool loadWifiConfig();
+bool loadMqttConfig();
+bool loadAquaMqttConfig();
+
+}  // namespace aquamqtt
+
+#endif  // AQUAMQTT_WEBCONFIG_H

--- a/AquaMQTT/include/handler/OTA.h
+++ b/AquaMQTT/include/handler/OTA.h
@@ -6,13 +6,16 @@ namespace aquamqtt
 class OTAHandler
 {
 public:
-    OTAHandler() = default;
+    OTAHandler() : mStarted(false) {}
 
     virtual ~OTAHandler() = default;
 
     void setup();
 
     void loop();
+
+private:
+    bool mStarted;
 };
 }  // namespace aquamqtt
 

--- a/AquaMQTT/include/handler/Web.h
+++ b/AquaMQTT/include/handler/Web.h
@@ -1,0 +1,30 @@
+#ifndef AQUAMQTT_WEB_H
+#define AQUAMQTT_WEB_H
+
+#include <ESPAsyncWebServer.h>
+
+namespace aquamqtt
+{
+
+class WebHandler
+{
+public:
+    WebHandler();
+    void setup();
+    void loop();
+
+private:
+    static void handleRoot(AsyncWebServerRequest* request);
+    static void handleNotFound(AsyncWebServerRequest* request);
+    static void handleWifiGet(AsyncWebServerRequest* request);
+    static void handleMqttGet(AsyncWebServerRequest* request);
+    static void handleAquaGet(AsyncWebServerRequest* request);
+    static void handleReboot(AsyncWebServerRequest* request);
+    static bool saveConfigFile(const String& filename, const String& content);
+
+    static AsyncWebServer mServer;
+};
+
+}  // namespace aquamqtt
+
+#endif  // AQUAMQTT_WEB_H

--- a/AquaMQTT/include/handler/Wifi.h
+++ b/AquaMQTT/include/handler/Wifi.h
@@ -12,9 +12,13 @@ public:
 
     virtual ~WifiHandler() = default;
 
-    void setup();
+    bool setup();
+
+    void setupAP();
 
     void loop();
+
+    static bool isConnected() { return mConnectedToWifiWithValidIpAddress; }
 
 private:
     static void wifiCallback(WiFiEvent_t event);

--- a/AquaMQTT/include/state/Optitronic2State.h
+++ b/AquaMQTT/include/state/Optitronic2State.h
@@ -80,6 +80,7 @@ public:
     float    getPvTargetSetpoint() const;
     float    getExtSourceMaxTemp() const;
     uint16_t getAntiLegioInterval() const;
+    uint16_t getExtSourcePriority() const;
 
     // --- Statistics ---
     struct Stats

--- a/AquaMQTT/include/state/Optitronic2State.h
+++ b/AquaMQTT/include/state/Optitronic2State.h
@@ -1,0 +1,128 @@
+#ifndef AQUAMQTT_OPTITRONIC2_STATE_H
+#define AQUAMQTT_OPTITRONIC2_STATE_H
+
+#include <Arduino.h>
+
+#include <cstdint>
+
+#include "message/optitronic2/RegisterMap.h"
+
+namespace aquamqtt
+{
+
+/**
+ * Thread-safe register state store for Optitronic 2.
+ * Stores the latest known register values and tracks changes.
+ */
+class Optitronic2State
+{
+public:
+    static Optitronic2State& getInstance();
+
+    virtual ~Optitronic2State() = default;
+
+    Optitronic2State(const Optitronic2State&)            = delete;
+    Optitronic2State& operator=(const Optitronic2State&) = delete;
+
+    /**
+     * Set the MQTT task handle for notifications when data changes
+     */
+    void setListener(TaskHandle_t handle);
+
+    /**
+     * Store register values from a parsed read response.
+     * Called by the listener task when it receives valid register data.
+     * @param startReg The starting register address
+     * @param values   Array of register values
+     * @param count    Number of registers
+     * @return true if any register value changed
+     */
+    bool storeRegisters(uint16_t startReg, const uint16_t* values, uint16_t count);
+
+    /**
+     * Store a single register write (observed on the bus or initiated by us)
+     */
+    bool storeSingleRegister(uint16_t reg, uint16_t value);
+
+    /**
+     * Read a register value. Returns false if the register has never been populated.
+     */
+    bool getRegister(uint16_t reg, uint16_t& value) const;
+
+    /**
+     * Check if a specific register block has been received at least once
+     */
+    bool hasBlock(uint16_t startReg) const;
+
+    // --- Typed accessors for common values ---
+
+    float    getWaterTemp() const;
+    float    getAmbientTemp() const;
+    float    getEvaporatorTemp() const;
+    float    getDhwSetpoint() const;
+    float    getActiveSetpoint() const;
+    float    getEcoDeviation() const;
+    float    getKomfortDeviation() const;
+    uint16_t getProgram() const;
+    uint16_t getAuxHeatMode() const;
+    uint16_t getExtInputFunction() const;
+    uint16_t getOperatingState() const;
+    bool     isPvActive() const;
+    bool     isQuickHeatActive() const;
+    float    getQuickHeatTarget() const;
+    bool     isForceHeating() const;
+
+    // Installer parameters (available after installer block is read)
+    float    getFrostProtectTemp() const;
+    float    getBivalentThreshold() const;
+    float    getPvTargetSetpoint() const;
+    float    getExtSourceMaxTemp() const;
+    uint16_t getAntiLegioInterval() const;
+
+    // --- Statistics ---
+    struct Stats
+    {
+        uint32_t framesReceived;
+        uint32_t crcErrors;
+        uint32_t registerUpdates;
+        uint32_t lastUpdateMs;
+    };
+
+    void  updateStats(uint32_t framesRx, uint32_t crcErr);
+    Stats getStats() const;
+
+    // Change tracking
+    bool     hasChanges() const;
+    void     clearChanges();
+    uint32_t getChangeFlags() const;
+
+    // Change flag bits
+    static constexpr uint32_t CHANGE_SENSORS   = (1UL << 0);
+    static constexpr uint32_t CHANGE_SETTINGS  = (1UL << 1);
+    static constexpr uint32_t CHANGE_STATE     = (1UL << 2);
+    static constexpr uint32_t CHANGE_INSTALLER = (1UL << 3);
+    static constexpr uint32_t CHANGE_SCHEDULE  = (1UL << 4);
+
+private:
+    Optitronic2State();
+
+    // Register storage: we use a flat array indexed by register address.
+    // The address space is sparse but bounded (max 0x0320 + some = ~810 regs).
+    // We'll use a compact approach with known blocks only.
+    static constexpr uint16_t MAX_REGISTER_ADDR = 0x0321;
+
+    uint16_t mRegisters[MAX_REGISTER_ADDR];
+    bool     mRegisterValid[MAX_REGISTER_ADDR];
+
+    TaskHandle_t      mNotify;
+    SemaphoreHandle_t mMutex;
+    uint32_t          mChangeFlags;
+
+    Stats mStats;
+
+    void notifyListener(uint32_t changeFlag);
+};
+
+}  // namespace aquamqtt
+
+#endif  // AQUAMQTT_OPTITRONIC2_STATE_H

--- a/AquaMQTT/include/state/Optitronic2State.h
+++ b/AquaMQTT/include/state/Optitronic2State.h
@@ -67,6 +67,8 @@ public:
     uint16_t getAuxHeatMode() const;
     uint16_t getExtInputFunction() const;
     uint16_t getOperatingState() const;
+    uint16_t getHeatSource() const;
+    uint16_t getCompressorStatus() const;
     bool     isPvActive() const;
     bool     isQuickHeatActive() const;
     float    getQuickHeatTarget() const;

--- a/AquaMQTT/include/task/ModbusListenerTask.h
+++ b/AquaMQTT/include/task/ModbusListenerTask.h
@@ -51,6 +51,8 @@ private:
     // Statistics
     uint32_t mFramesReceived;
     uint32_t mCrcErrors;
+    uint32_t mRawBytesReceived;
+    uint32_t mRawBytesHmi;
     uint32_t mLastStatsUpdate;
 };
 

--- a/AquaMQTT/include/task/ModbusListenerTask.h
+++ b/AquaMQTT/include/task/ModbusListenerTask.h
@@ -1,0 +1,59 @@
+#ifndef AQUAMQTT_MODBUS_LISTENER_TASK_H
+#define AQUAMQTT_MODBUS_LISTENER_TASK_H
+
+#include <Arduino.h>
+
+#include "message/optitronic2/ModbusRtuFrame.h"
+#include "message/optitronic2/RegisterMap.h"
+
+namespace aquamqtt
+{
+
+/**
+ * Task that listens on the Modbus RTU bus (passive sniff) and parses
+ * request/response pairs from the Optitronic 2 protocol.
+ *
+ * On the half-duplex bus, we see interleaved traffic:
+ *   Master (HMI) -> Read Request (fn=0x03)
+ *   Slave (Main) -> Read Response (fn=0x03)
+ *   Master (HMI) -> Write Single (fn=0x06)
+ *   Slave (Main) -> Write Echo (fn=0x06)
+ *   etc.
+ *
+ * Frame boundaries are detected by inter-character silence (>2ms at 57600 baud).
+ */
+class ModbusListenerTask
+{
+public:
+    ModbusListenerTask();
+
+    void spawn();
+
+private:
+    [[noreturn]] static void innerTask(void* pvParameters);
+
+    void setup();
+    void loop();
+    void processFrame();
+
+    // Frame assembly buffer
+    uint8_t       mFrameBuffer[message::optitronic2::MODBUS_MAX_FRAME_SIZE];
+    uint8_t       mFrameLength;
+    unsigned long mLastByteTime;
+    bool          mFrameInProgress;
+
+    // Request tracking: we need to know what the last read request was
+    // so we can map the response data back to register addresses
+    bool     mPendingReadRequest;
+    uint16_t mPendingReadStartReg;
+    uint16_t mPendingReadQuantity;
+
+    // Statistics
+    uint32_t mFramesReceived;
+    uint32_t mCrcErrors;
+    uint32_t mLastStatsUpdate;
+};
+
+}  // namespace aquamqtt
+
+#endif  // AQUAMQTT_MODBUS_LISTENER_TASK_H

--- a/AquaMQTT/include/task/ModbusRelayTask.h
+++ b/AquaMQTT/include/task/ModbusRelayTask.h
@@ -1,0 +1,92 @@
+#ifndef AQUAMQTT_MODBUS_RELAY_TASK_H
+#define AQUAMQTT_MODBUS_RELAY_TASK_H
+
+#include <Arduino.h>
+
+#include "message/optitronic2/ModbusRtuFrame.h"
+#include "message/optitronic2/RegisterMap.h"
+
+namespace aquamqtt
+{
+
+/**
+ * Task that sits between HMI and Main Controller on the Modbus RTU bus (MITM).
+ *
+ * With the passthrough jumper removed, this task:
+ *   1. Receives frames from HMI (Serial1) → forwards to Main (Serial2)
+ *   2. Receives frames from Main (Serial2) → forwards to HMI (Serial1)
+ *   3. Parses all traffic for state extraction (same as listener)
+ *   4. Can inject modified write frames when MQTT commands are pending
+ *
+ * Both serial lines are half-duplex at 57600 8N1.
+ * Frame boundaries are detected by inter-character silence (>2ms).
+ */
+class ModbusRelayTask
+{
+public:
+    ModbusRelayTask();
+
+    void spawn();
+    void setup();
+    void loop();
+
+private:
+    [[noreturn]] static void innerTask(void* pvParameters);
+
+    // Process a complete frame received from one side and forward to the other
+    void processAndForward(uint8_t* buffer, uint8_t length, HardwareSerial& destination, bool fromHmi);
+    void parseFrame(uint8_t* buffer, uint8_t length, bool fromHmi);
+    void injectPendingWrites();
+
+    // HMI side (Serial1) frame assembly
+    uint8_t       mHmiFrameBuffer[message::optitronic2::MODBUS_MAX_FRAME_SIZE];
+    uint8_t       mHmiFrameLength;
+    unsigned long mHmiLastByteTime;
+    bool          mHmiFrameInProgress;
+
+    // Main controller side (Serial2) frame assembly
+    uint8_t       mMainFrameBuffer[message::optitronic2::MODBUS_MAX_FRAME_SIZE];
+    uint8_t       mMainFrameLength;
+    unsigned long mMainLastByteTime;
+    bool          mMainFrameInProgress;
+
+    // Request tracking for response mapping
+    bool     mPendingReadRequest;
+    uint16_t mPendingReadStartReg;
+    uint16_t mPendingReadQuantity;
+
+    // Statistics
+    uint32_t mFramesReceived;
+    uint32_t mCrcErrors;
+    uint32_t mFramesRelayed;
+    uint32_t mWritesInjected;
+    uint32_t mHmiFramesIn;
+    uint32_t mMainFramesIn;
+    uint32_t mHmiBytesIn;
+    uint32_t mMainBytesIn;
+    uint32_t mLastStatsUpdate;
+    uint32_t mEchoBytes;
+    uint32_t mTxBytesWritten;
+
+    // Last forwarded frame for debugging
+    uint8_t  mLastFwdFrame[32];
+    uint8_t  mLastFwdFrameLen;
+
+public:
+    uint32_t getFramesReceived() const { return mFramesReceived; }
+    uint32_t getCrcErrors() const { return mCrcErrors; }
+    uint32_t getFramesRelayed() const { return mFramesRelayed; }
+    uint32_t getHmiFramesIn() const { return mHmiFramesIn; }
+    uint32_t getMainFramesIn() const { return mMainFramesIn; }
+    uint32_t getHmiBytesIn() const { return mHmiBytesIn; }
+    uint32_t getMainBytesIn() const { return mMainBytesIn; }
+    uint32_t getEchoBytes() const { return mEchoBytes; }
+    uint32_t getTxBytesWritten() const { return mTxBytesWritten; }
+    uint32_t getWritesInjected() const { return mWritesInjected; }
+    const uint8_t* getLastFwdFrame() const { return mLastFwdFrame; }
+    uint8_t getLastFwdFrameLen() const { return mLastFwdFrameLen; }
+};
+
+}  // namespace aquamqtt
+
+#endif  // AQUAMQTT_MODBUS_RELAY_TASK_H

--- a/AquaMQTT/include/task/ModbusRelayTask.h
+++ b/AquaMQTT/include/task/ModbusRelayTask.h
@@ -37,6 +37,9 @@ private:
     void processAndForward(uint8_t* buffer, uint8_t length, HardwareSerial& destination, bool fromHmi);
     void parseFrame(uint8_t* buffer, uint8_t length, bool fromHmi);
     void injectPendingWrites();
+    void injectPeriodicReads();
+    void sendToMain(uint8_t* frame, uint8_t len);
+    int  receiveFromMain(uint8_t* buf, uint8_t maxLen, uint16_t timeoutMs = 100);
 
     // HMI side (Serial1) frame assembly
     uint8_t       mHmiFrameBuffer[message::optitronic2::MODBUS_MAX_FRAME_SIZE];
@@ -67,6 +70,10 @@ private:
     uint32_t mLastStatsUpdate;
     uint32_t mEchoBytes;
     uint32_t mTxBytesWritten;
+
+    // Periodic read injection
+    unsigned long mLastPeriodicRead;
+    uint8_t       mPeriodicReadIndex;
 
     // Last forwarded frame for debugging
     uint8_t  mLastFwdFrame[32];

--- a/AquaMQTT/include/task/Optitronic2MQTTTask.h
+++ b/AquaMQTT/include/task/Optitronic2MQTTTask.h
@@ -29,6 +29,9 @@ public:
     bool hasPendingWrite() const;
     bool dequeuePendingWrite(uint16_t& reg, uint16_t& value);
 
+    // Queue a register write (used by MQTT handler and web API)
+    void queueWrite(uint16_t reg, uint16_t value);
+
 private:
     [[noreturn]] static void innerTask(void* pvParameters);
 
@@ -51,7 +54,6 @@ private:
     void handleSetForceHeating(bool enable);
     void handleSetQuickHeat(bool activate, float target);
     void handleTriggerAntiLegionella();
-    void queueWrite(uint16_t reg, uint16_t value);
 
     // Publish helper
     void publishFloat(const char* subtopic, float value, uint8_t decimals = 1);

--- a/AquaMQTT/include/task/Optitronic2MQTTTask.h
+++ b/AquaMQTT/include/task/Optitronic2MQTTTask.h
@@ -51,6 +51,7 @@ private:
     void handleSetForceHeating(bool enable);
     void handleSetQuickHeat(bool activate, float target);
     void handleTriggerAntiLegionella();
+    void queueWrite(uint16_t reg, uint16_t value);
 
     // Publish helper
     void publishFloat(const char* subtopic, float value, uint8_t decimals = 1);

--- a/AquaMQTT/include/task/Optitronic2MQTTTask.h
+++ b/AquaMQTT/include/task/Optitronic2MQTTTask.h
@@ -1,0 +1,86 @@
+#ifndef AQUAMQTT_OPTITRONIC2_MQTT_TASK_H
+#define AQUAMQTT_OPTITRONIC2_MQTT_TASK_H
+
+#include <Arduino.h>
+#include <MQTTClient.h>
+#include <WiFiClient.h>
+
+namespace aquamqtt
+{
+
+/**
+ * MQTT task for Optitronic 2 protocol.
+ * Publishes register data as human-readable MQTT topics and
+ * handles incoming commands (write requests) via MQTT.
+ *
+ * Also provides HA MQTT auto-discovery.
+ */
+class Optitronic2MQTTTask
+{
+public:
+    Optitronic2MQTTTask();
+
+    void spawn();
+
+    // Called by static MQTT callback trampoline
+    void handleMessage(const String& topic, const String& payload);
+
+    // Called by ModbusListenerTask to check if there are pending writes
+    bool hasPendingWrite() const;
+    bool dequeuePendingWrite(uint16_t& reg, uint16_t& value);
+
+private:
+    [[noreturn]] static void innerTask(void* pvParameters);
+
+    void setup();
+    void loop();
+
+    void connectMqtt();
+    void publishAll();
+    void publishSensors();
+    void publishSettings();
+    void publishState();
+    void publishInstaller();
+    void publishStats();
+    void publishDiscovery();
+
+    // MQTT write command: sends Modbus write via serial
+    void handleSetDhwSetpoint(float temp);
+    void handleSetProgram(uint16_t program);
+    void handleSetExtInputFunction(uint16_t fn);
+    void handleSetForceHeating(bool enable);
+    void handleSetQuickHeat(bool activate, float target);
+    void handleTriggerAntiLegionella();
+
+    // Publish helper
+    void publishFloat(const char* subtopic, float value, uint8_t decimals = 1);
+    void publishInt(const char* subtopic, int value);
+    void publishString(const char* subtopic, const char* value);
+    void publishBool(const char* subtopic, bool value);
+
+    MQTTClient    mMQTTClient;
+    WiFiClient    mWiFiClient;
+    TaskHandle_t  mTaskHandle;
+    char          mTopicBuffer[128];
+    char          mPayloadBuffer[64];
+
+    unsigned long mLastFullUpdate;
+    unsigned long mLastStatsUpdate;
+    bool          mPublishedDiscovery;
+
+    // Write queue (commands received via MQTT, forwarded to serial in listener task context)
+    struct WriteCommand
+    {
+        uint16_t reg;
+        uint16_t value;
+        bool     pending;
+    };
+    static constexpr uint8_t WRITE_QUEUE_SIZE = 8;
+    WriteCommand mWriteQueue[WRITE_QUEUE_SIZE];
+    uint8_t      mWriteQueueHead;
+    SemaphoreHandle_t mWriteMutex;
+};
+
+}  // namespace aquamqtt
+
+#endif  // AQUAMQTT_OPTITRONIC2_MQTT_TASK_H

--- a/AquaMQTT/lib/AtlanticSerialProtocol/include/message/MessageConstants.h
+++ b/AquaMQTT/lib/AtlanticSerialProtocol/include/message/MessageConstants.h
@@ -22,9 +22,10 @@ enum class FrameBufferChannel
 enum ProtocolVersion
 {
     PROTOCOL_UNKNOWN = -1,
-    PROTOCOL_LEGACY  = 0,
-    PROTOCOL_NEXT    = 1,
-    PROTOCOL_ODYSSEE = 2
+    PROTOCOL_LEGACY      = 0,
+    PROTOCOL_NEXT        = 1,
+    PROTOCOL_ODYSSEE     = 2,
+    PROTOCOL_OPTITRONIC2 = 3
 };
 
 enum ProtocolChecksum

--- a/AquaMQTT/lib/AtlanticSerialProtocol/include/message/optitronic2/ModbusRtuFrame.h
+++ b/AquaMQTT/lib/AtlanticSerialProtocol/include/message/optitronic2/ModbusRtuFrame.h
@@ -1,0 +1,137 @@
+#ifndef AQUAMQTT_MODBUS_RTU_FRAME_H
+#define AQUAMQTT_MODBUS_RTU_FRAME_H
+
+#include <cstdint>
+
+namespace aquamqtt::message::optitronic2
+{
+
+/**
+ * Modbus RTU function codes used by the Optitronic 2 protocol
+ */
+enum ModbusFunctionCode : uint8_t
+{
+    FC_READ_HOLDING_REGISTERS  = 0x03,
+    FC_WRITE_SINGLE_REGISTER   = 0x06,
+    FC_WRITE_MULTIPLE_REGISTERS = 0x10,
+};
+
+/**
+ * Maximum Modbus RTU frame size.
+ * Largest expected frame: fn=0x10 write of 42 registers (ventilation schedule)
+ * = 1 (addr) + 1 (fn) + 2 (start) + 2 (qty) + 1 (byte count) + 84 (data) + 2 (CRC) = 93 bytes
+ */
+constexpr uint8_t MODBUS_MAX_FRAME_SIZE = 128;
+
+/**
+ * Optitronic 2 bus parameters
+ */
+constexpr uint8_t       MODBUS_SLAVE_ADDRESS = 0x01;
+constexpr unsigned long MODBUS_BAUD_RATE     = 57600;
+
+/**
+ * Inter-frame silence detection threshold.
+ * Modbus RTU spec: 3.5 character times. At 57600 baud (11 bits/char):
+ * 3.5 * 11 / 57600 = ~0.67ms. We use 2ms for safety margin.
+ */
+constexpr unsigned long MODBUS_FRAME_SILENCE_MS = 2;
+
+/**
+ * Parsed Modbus RTU frame
+ */
+struct ModbusFrame
+{
+    uint8_t slaveAddress;
+    uint8_t functionCode;
+    uint8_t data[MODBUS_MAX_FRAME_SIZE - 4];  // minus addr, fn, crc16
+    uint8_t dataLength;
+    bool    valid;
+};
+
+/**
+ * Parsed read request (fn=0x03 from master)
+ */
+struct ModbusReadRequest
+{
+    uint16_t startRegister;
+    uint16_t quantity;
+};
+
+/**
+ * Parsed read response (fn=0x03 from slave)
+ */
+struct ModbusReadResponse
+{
+    uint8_t  byteCount;
+    uint16_t registers[50];  // max 50 registers per response
+    uint8_t  registerCount;
+};
+
+/**
+ * Parsed write single register (fn=0x06)
+ */
+struct ModbusWriteSingle
+{
+    uint16_t registerAddress;
+    uint16_t value;
+};
+
+/**
+ * Parsed write multiple registers (fn=0x10)
+ */
+struct ModbusWriteMultiple
+{
+    uint16_t startRegister;
+    uint16_t quantity;
+    uint16_t values[50];
+};
+
+/**
+ * CRC-16/Modbus calculation
+ */
+uint16_t modbusRtuCrc16(const uint8_t* data, uint8_t length);
+
+/**
+ * Parse a raw byte buffer into a ModbusFrame structure.
+ * Returns true if frame is valid (correct CRC and minimum length).
+ */
+bool parseModbusFrame(const uint8_t* buffer, uint8_t length, ModbusFrame& frame);
+
+/**
+ * Parse a read request from frame data (fn=0x03 master request)
+ */
+bool parseReadRequest(const ModbusFrame& frame, ModbusReadRequest& request);
+
+/**
+ * Parse a read response from frame data (fn=0x03 slave response)
+ */
+bool parseReadResponse(const ModbusFrame& frame, ModbusReadResponse& response);
+
+/**
+ * Parse a write single register from frame data (fn=0x06)
+ */
+bool parseWriteSingle(const ModbusFrame& frame, ModbusWriteSingle& write);
+
+/**
+ * Parse a write multiple registers from frame data (fn=0x10 master request)
+ */
+bool parseWriteMultiple(const ModbusFrame& frame, ModbusWriteMultiple& write);
+
+/**
+ * Build a Modbus RTU read request frame
+ */
+uint8_t buildReadRequest(uint8_t slaveAddr, uint16_t startReg, uint16_t qty, uint8_t* buffer);
+
+/**
+ * Build a Modbus RTU write single register frame
+ */
+uint8_t buildWriteSingle(uint8_t slaveAddr, uint16_t reg, uint16_t value, uint8_t* buffer);
+
+/**
+ * Build a Modbus RTU write multiple registers frame
+ */
+uint8_t buildWriteMultiple(uint8_t slaveAddr, uint16_t startReg, uint16_t qty, const uint16_t* values, uint8_t* buffer);
+
+}  // namespace aquamqtt::message::optitronic2
+
+#endif  // AQUAMQTT_MODBUS_RTU_FRAME_H

--- a/AquaMQTT/lib/AtlanticSerialProtocol/include/message/optitronic2/RegisterMap.h
+++ b/AquaMQTT/lib/AtlanticSerialProtocol/include/message/optitronic2/RegisterMap.h
@@ -19,8 +19,10 @@ constexpr uint16_t REG_BLOCK1_START = 0x0000;
 constexpr uint16_t REG_BLOCK1_COUNT = 25;
 
 constexpr uint16_t REG_ACTIVE_SETPOINT     = 0x0000;  // int16 ×0.1°C (effective target, e.g. 450=45.0°C or 700=70.0°C in PV mode)
-constexpr uint16_t REG_OPERATING_STATE     = 0x0001;  // enum: 2=idle/heating, 6=PV-boost
-constexpr uint16_t REG_OPERATING_SUBSTATE  = 0x0002;  // enum: 2=normal, 3=?
+constexpr uint16_t REG_OPERATING_STATE     = 0x0001;  // enum: 2=idle, 3=heating, 6=PV-boost
+constexpr uint16_t REG_OPERATING_SUBSTATE  = 0x0002;  // enum: 0=init, 3=normal
+constexpr uint16_t REG_HEAT_SOURCE_ACTIVE  = 0x0005;  // enum: 0=off, 2=heat_pump (1=electric?, 3=both?)
+constexpr uint16_t REG_FAN_COMPRESSOR_LVL  = 0x0006;  // enum: 0=off, 3=high (1=low?, 2=med?)
 constexpr uint16_t REG_DHW_SETPOINT        = 0x0009;  // int16 ×0.1°C (user setting, e.g. 550=55.0°C)
 constexpr uint16_t REG_ECO_DEVIATION       = 0x000A;  // int16 ×0.1°C (signed, e.g. 0xFF9C = -10.0°C)
 constexpr uint16_t REG_KOMFORT_DEVIATION   = 0x000B;  // int16 ×0.1°C (e.g. 0x0014 = +2.0°C)
@@ -41,7 +43,7 @@ constexpr uint16_t REG_WATER_TEMP          = 0x00C8;  // int16 ×0.1°C (tank to
 constexpr uint16_t REG_SENSOR_UNKNOWN_C9   = 0x00C9;  // 0xF334 — pressure transducer?
 constexpr uint16_t REG_AMBIENT_TEMP        = 0x00CA;  // int16 ×0.1°C (intake/ambient air)
 constexpr uint16_t REG_EVAPORATOR_TEMP     = 0x00CB;  // int16 ×0.1°C (evaporator/collector)
-constexpr uint16_t REG_PV_INPUT_STATUS     = 0x00D1;  // enum: 0=open (no PV), 4=closed (PV active)
+constexpr uint16_t REG_COMPRESSOR_STATUS   = 0x00D1;  // enum: 0=none, 2=demand-triggered, 4=PV-signal-triggered (latched)
 
 // Block 3: Status Flags (0x00E1 + 6 regs)
 constexpr uint16_t REG_BLOCK3_START = 0x00E1;
@@ -121,15 +123,32 @@ enum Optitronic2ExtInputFunction : uint16_t
 
 enum Optitronic2OperatingState : uint16_t
 {
-    STATE_IDLE_HEATING = 2,
+    STATE_IDLE         = 2,
+    STATE_HEATING      = 3,
     STATE_PV_BOOST     = 6,
 };
 
-enum Optitronic2PvStatus : uint16_t
+enum Optitronic2HeatSource : uint16_t
 {
-    PV_STATUS_INACTIVE = 0,
-    PV_STATUS_ACTIVE   = 4,
+    HEAT_SRC_OFF       = 0,
+    HEAT_SRC_ELECTRIC  = 1,
+    HEAT_SRC_HEATPUMP  = 2,
+    HEAT_SRC_BOTH      = 3,
 };
+
+enum Optitronic2CompressorStatus : uint16_t
+{
+    COMP_IDLE          = 0,
+    COMP_RUNNING       = 2,
+    COMP_PV_ACTIVE     = 4,
+};
+
+// Schedule encoding: bits 15:13 = type (001=start, 111=end), bits 6:0 = quarter-hours (0-95 = 00:00-23:45)
+// 0xFFFF = disabled slot. 7 days × 6 regs (3 start/end pairs per day).
+constexpr uint16_t SCHED_FLAG_START = 0x2000;
+constexpr uint16_t SCHED_FLAG_END   = 0xE000;
+constexpr uint16_t SCHED_TIME_MASK  = 0x007F;
+constexpr uint16_t SCHED_DISABLED   = 0xFFFF;
 
 // Quick-heat register bit manipulation
 constexpr uint16_t QUICK_HEAT_ACTIVATE_BIT = 0x8000;

--- a/AquaMQTT/lib/AtlanticSerialProtocol/include/message/optitronic2/RegisterMap.h
+++ b/AquaMQTT/lib/AtlanticSerialProtocol/include/message/optitronic2/RegisterMap.h
@@ -123,9 +123,15 @@ enum Optitronic2ExtInputFunction : uint16_t
 
 enum Optitronic2OperatingState : uint16_t
 {
-    STATE_IDLE         = 2,
-    STATE_HEATING      = 3,
-    STATE_PV_BOOST     = 6,
+    STATE_OFF              = 0,
+    STATE_STANDBY          = 1,
+    STATE_IDLE             = 2,
+    STATE_HEATING          = 3,
+    STATE_HEATING_ELECTRIC = 4,
+    STATE_HEATING_BOTH     = 5,
+    STATE_PV_BOOST         = 6,
+    STATE_DEFROST          = 7,
+    STATE_ANTI_LEGIONELLA  = 8,
 };
 
 enum Optitronic2HeatSource : uint16_t

--- a/AquaMQTT/lib/AtlanticSerialProtocol/include/message/optitronic2/RegisterMap.h
+++ b/AquaMQTT/lib/AtlanticSerialProtocol/include/message/optitronic2/RegisterMap.h
@@ -1,0 +1,165 @@
+#ifndef AQUAMQTT_OPTITRONIC2_REGISTER_MAP_H
+#define AQUAMQTT_OPTITRONIC2_REGISTER_MAP_H
+
+#include <cstdint>
+
+namespace aquamqtt::message::optitronic2
+{
+
+/**
+ * Optitronic 2 Modbus register map — reverse-engineered from Austria Email WPA 450 ECO.
+ * Slave address: 0x01, Baud: 57600, 8N1.
+ * HMI is master, main controller is slave.
+ */
+
+// --- Periodic read blocks (polled by HMI every ~600ms cycle) ---
+
+// Block 1: Settings + Operating State (0x0000 + 25 regs)
+constexpr uint16_t REG_BLOCK1_START = 0x0000;
+constexpr uint16_t REG_BLOCK1_COUNT = 25;
+
+constexpr uint16_t REG_ACTIVE_SETPOINT     = 0x0000;  // int16 ×0.1°C (effective target, e.g. 450=45.0°C or 700=70.0°C in PV mode)
+constexpr uint16_t REG_OPERATING_STATE     = 0x0001;  // enum: 2=idle/heating, 6=PV-boost
+constexpr uint16_t REG_OPERATING_SUBSTATE  = 0x0002;  // enum: 2=normal, 3=?
+constexpr uint16_t REG_DHW_SETPOINT        = 0x0009;  // int16 ×0.1°C (user setting, e.g. 550=55.0°C)
+constexpr uint16_t REG_ECO_DEVIATION       = 0x000A;  // int16 ×0.1°C (signed, e.g. 0xFF9C = -10.0°C)
+constexpr uint16_t REG_KOMFORT_DEVIATION   = 0x000B;  // int16 ×0.1°C (e.g. 0x0014 = +2.0°C)
+constexpr uint16_t REG_PROGRAM             = 0x000C;  // enum: 1=NORMAL, 2=ECO, 3=KOMFORT, 4=KOMFORT_PLUS
+constexpr uint16_t REG_AUX_HEAT_MODE       = 0x000D;  // enum: 1=electric, 2=external, 3=both
+constexpr uint16_t REG_FORCE_HEATING       = 0x000F;  // bool: 1=start, 0=cancel (quick heat)
+constexpr uint16_t REG_ANTI_LEGIONELLA     = 0x0010;  // bool: 1=trigger, self-clears
+constexpr uint16_t REG_EXT_INPUT_FUNCTION  = 0x0011;  // enum: see EXT_INPUT_* below
+constexpr uint16_t REG_UNKNOWN_12          = 0x0012;  // always 0x00C8 (200)
+constexpr uint16_t REG_SETPOINT_MIRROR     = 0x0013;  // mirrors REG_DHW_SETPOINT
+constexpr uint16_t REG_QUICK_HEAT_STATE    = 0x0016;  // int16: bit15=active, lower bits=target ×0.1°C
+
+// Block 2: Sensor Data (0x00C8 + 10 regs)
+constexpr uint16_t REG_BLOCK2_START = 0x00C8;
+constexpr uint16_t REG_BLOCK2_COUNT = 10;
+
+constexpr uint16_t REG_WATER_TEMP          = 0x00C8;  // int16 ×0.1°C (tank top)
+constexpr uint16_t REG_SENSOR_UNKNOWN_C9   = 0x00C9;  // 0xF334 — pressure transducer?
+constexpr uint16_t REG_AMBIENT_TEMP        = 0x00CA;  // int16 ×0.1°C (intake/ambient air)
+constexpr uint16_t REG_EVAPORATOR_TEMP     = 0x00CB;  // int16 ×0.1°C (evaporator/collector)
+constexpr uint16_t REG_PV_INPUT_STATUS     = 0x00D1;  // enum: 0=open (no PV), 4=closed (PV active)
+
+// Block 3: Status Flags (0x00E1 + 6 regs)
+constexpr uint16_t REG_BLOCK3_START = 0x00E1;
+constexpr uint16_t REG_BLOCK3_COUNT = 6;
+
+// Block 4: Unknown (0x0197 + 1 reg)
+constexpr uint16_t REG_BLOCK4_START = 0x0197;
+constexpr uint16_t REG_BLOCK4_COUNT = 1;
+
+// Block 5: Unknown (0x0320 + 1 reg)
+constexpr uint16_t REG_BLOCK5_START = 0x0320;
+constexpr uint16_t REG_BLOCK5_COUNT = 1;
+
+// --- On-demand read blocks ---
+
+// DHW Schedule (0x0032 + 42 regs) — triggered by schedule menu
+constexpr uint16_t REG_SCHEDULE_DHW_START = 0x0032;
+constexpr uint16_t REG_SCHEDULE_DHW_COUNT = 42;
+
+// Installer Block 1 (0x015E + 25 regs) — triggered by installer PIN entry
+constexpr uint16_t REG_INSTALLER_BLK1_START = 0x015E;
+constexpr uint16_t REG_INSTALLER_BLK1_COUNT = 25;
+
+// Installer Block 2 (0x0190 + 25 regs)
+constexpr uint16_t REG_INSTALLER_BLK2_START = 0x0190;
+constexpr uint16_t REG_INSTALLER_BLK2_COUNT = 25;
+
+// Ventilation Schedule (0x01C2 + 42 regs) — installer only
+constexpr uint16_t REG_SCHEDULE_VENT_START = 0x01C2;
+constexpr uint16_t REG_SCHEDULE_VENT_COUNT = 42;
+
+// --- Installer settings (writable via fn=0x06) ---
+
+constexpr uint16_t REG_ANTI_LEGIO_INTERVAL   = 0x015E;  // days (0=OFF)
+constexpr uint16_t REG_ANTI_LEGIO_HYSTERESIS = 0x015F;  // ×0.1°C
+constexpr uint16_t REG_FROST_PROTECT_TEMP    = 0x0160;  // ×0.1°C (default 70 = 7.0°C)
+constexpr uint16_t REG_EXT_SOURCE_PRIORITY   = 0x0163;  // enum: 0=device, 1=external
+constexpr uint16_t REG_PV_TARGET_SETPOINT    = 0x019F;  // ×0.1°C (default 700 = 70.0°C)
+constexpr uint16_t REG_BIVALENT_THRESHOLD    = 0x01A0;  // ×0.1°C (default 30 = 3.0°C)
+constexpr uint16_t REG_EXT_SOURCE_MAX_TEMP   = 0x01A3;  // ×0.1°C (default 600 = 60.0°C)
+
+// --- Modification log triplet (written with fn=0x10 to 0x00DE-0x00E0) ---
+
+constexpr uint16_t REG_RTC_MINUTE_COUNTER = 0x00DE;  // monotonic, high byte 0x82xx
+constexpr uint16_t REG_LOG_MAGIC          = 0x00DF;  // always 0x34AE
+constexpr uint16_t REG_LOG_SEQUENCE       = 0x00E0;  // wraps at ~60
+
+// --- Enums ---
+
+enum Optitronic2Program : uint16_t
+{
+    PROGRAM_NORMAL       = 1,
+    PROGRAM_ECO          = 2,
+    PROGRAM_KOMFORT      = 3,
+    PROGRAM_KOMFORT_PLUS = 4,
+};
+
+enum Optitronic2AuxHeatMode : uint16_t
+{
+    AUX_HEAT_ELECTRIC = 1,
+    AUX_HEAT_EXTERNAL = 2,
+    AUX_HEAT_BOTH     = 3,
+};
+
+enum Optitronic2ExtInputFunction : uint16_t
+{
+    EXT_INPUT_QUICK_HEAT    = 0,
+    EXT_INPUT_OFF           = 1,
+    EXT_INPUT_NORMAL        = 2,
+    EXT_INPUT_ECO           = 3,
+    EXT_INPUT_KOMFORT       = 4,
+    EXT_INPUT_KOMFORT_PLUS  = 5,
+    EXT_INPUT_PHOTOVOLTAIK  = 6,
+    EXT_INPUT_RESERVE       = 7,
+    EXT_INPUT_FUNCTION_1    = 8,
+};
+
+enum Optitronic2OperatingState : uint16_t
+{
+    STATE_IDLE_HEATING = 2,
+    STATE_PV_BOOST     = 6,
+};
+
+enum Optitronic2PvStatus : uint16_t
+{
+    PV_STATUS_INACTIVE = 0,
+    PV_STATUS_ACTIVE   = 4,
+};
+
+// Quick-heat register bit manipulation
+constexpr uint16_t QUICK_HEAT_ACTIVATE_BIT = 0x8000;
+
+inline bool isQuickHeatActive(uint16_t regValue)
+{
+    return (regValue & QUICK_HEAT_ACTIVATE_BIT) != 0;
+}
+
+inline uint16_t getQuickHeatTarget(uint16_t regValue)
+{
+    return regValue & 0x7FFF;
+}
+
+inline uint16_t makeQuickHeatActivate(uint16_t targetRaw)
+{
+    return targetRaw | QUICK_HEAT_ACTIVATE_BIT;
+}
+
+// Temperature encoding helpers
+inline float regToTemp(uint16_t raw)
+{
+    return static_cast<int16_t>(raw) * 0.1f;
+}
+
+inline uint16_t tempToReg(float temp)
+{
+    return static_cast<uint16_t>(static_cast<int16_t>(temp * 10.0f));
+}
+
+}  // namespace aquamqtt::message::optitronic2
+
+#endif  // AQUAMQTT_OPTITRONIC2_REGISTER_MAP_H

--- a/AquaMQTT/lib/AtlanticSerialProtocol/include/mqtt/MQTTDefinitions.h
+++ b/AquaMQTT/lib/AtlanticSerialProtocol/include/mqtt/MQTTDefinitions.h
@@ -20,9 +20,10 @@ constexpr char ENUM_UNKNOWN[] = { "UNKNOWN" };
 constexpr char ENUM_AQUAMQTT_MODE_LISTENER[] = { "LISTENER" };
 constexpr char ENUM_AQUAMQTT_MODE_MITM[]     = { "MITM" };
 
-constexpr char ENUM_AQUAMQTT_PROTOCOL_LEGACY[]  = { "LEGACY" };
-constexpr char ENUM_AQUAMQTT_PROTOCOL_NEXT[]    = { "NEXT" };
-constexpr char ENUM_AQUAMQTT_PROTOCOL_ODYSSEE[] = { "ODYSSEE" };
+constexpr char ENUM_AQUAMQTT_PROTOCOL_LEGACY[]      = { "LEGACY" };
+constexpr char ENUM_AQUAMQTT_PROTOCOL_NEXT[]        = { "NEXT" };
+constexpr char ENUM_AQUAMQTT_PROTOCOL_ODYSSEE[]     = { "ODYSSEE" };
+constexpr char ENUM_AQUAMQTT_PROTOCOL_OPTITRONIC2[] = { "OPTITRONIC2" };
 
 constexpr char ENUM_BRAND_ATLANTIC[] = { "Atlantic" };
 constexpr char ENUM_BRAND_THERMOR[]  = { "Thermor" };

--- a/AquaMQTT/lib/AtlanticSerialProtocol/src/message/optitronic2/ModbusRtuFrame.cpp
+++ b/AquaMQTT/lib/AtlanticSerialProtocol/src/message/optitronic2/ModbusRtuFrame.cpp
@@ -1,0 +1,219 @@
+#include "message/optitronic2/ModbusRtuFrame.h"
+
+namespace aquamqtt::message::optitronic2
+{
+
+uint16_t modbusRtuCrc16(const uint8_t* data, uint8_t length)
+{
+    uint16_t crc = 0xFFFF;
+    for (uint8_t i = 0; i < length; i++)
+    {
+        crc ^= static_cast<uint16_t>(data[i]);
+        for (uint8_t j = 0; j < 8; j++)
+        {
+            if (crc & 0x0001)
+            {
+                crc >>= 1;
+                crc ^= 0xA001;
+            }
+            else
+            {
+                crc >>= 1;
+            }
+        }
+    }
+    return crc;
+}
+
+bool parseModbusFrame(const uint8_t* buffer, uint8_t length, ModbusFrame& frame)
+{
+    frame.valid = false;
+
+    // minimum frame size: addr(1) + fn(1) + data(1) + crc(2) = 5
+    if (length < 5)
+    {
+        return false;
+    }
+
+    // verify CRC
+    uint16_t receivedCrc = static_cast<uint16_t>(buffer[length - 2]) | (static_cast<uint16_t>(buffer[length - 1]) << 8);
+    uint16_t calculatedCrc = modbusRtuCrc16(buffer, length - 2);
+
+    if (receivedCrc != calculatedCrc)
+    {
+        return false;
+    }
+
+    frame.slaveAddress = buffer[0];
+    frame.functionCode = buffer[1];
+    frame.dataLength   = length - 4;  // minus addr, fn, crc16
+    if (frame.dataLength > sizeof(frame.data))
+    {
+        return false;
+    }
+    for (uint8_t i = 0; i < frame.dataLength; i++)
+    {
+        frame.data[i] = buffer[2 + i];
+    }
+    frame.valid = true;
+    return true;
+}
+
+bool parseReadRequest(const ModbusFrame& frame, ModbusReadRequest& request)
+{
+    if (!frame.valid || frame.functionCode != FC_READ_HOLDING_REGISTERS)
+    {
+        return false;
+    }
+    if (frame.dataLength != 4)
+    {
+        return false;
+    }
+
+    request.startRegister = (static_cast<uint16_t>(frame.data[0]) << 8) | frame.data[1];
+    request.quantity      = (static_cast<uint16_t>(frame.data[2]) << 8) | frame.data[3];
+    return true;
+}
+
+bool parseReadResponse(const ModbusFrame& frame, ModbusReadResponse& response)
+{
+    if (!frame.valid || frame.functionCode != FC_READ_HOLDING_REGISTERS)
+    {
+        return false;
+    }
+    if (frame.dataLength < 1)
+    {
+        return false;
+    }
+
+    response.byteCount = frame.data[0];
+
+    if (frame.dataLength != static_cast<uint8_t>(1 + response.byteCount))
+    {
+        return false;
+    }
+    if (response.byteCount % 2 != 0)
+    {
+        return false;
+    }
+
+    response.registerCount = response.byteCount / 2;
+    if (response.registerCount > 50)
+    {
+        return false;
+    }
+
+    for (uint8_t i = 0; i < response.registerCount; i++)
+    {
+        response.registers[i] = (static_cast<uint16_t>(frame.data[1 + i * 2]) << 8) | frame.data[2 + i * 2];
+    }
+
+    return true;
+}
+
+bool parseWriteSingle(const ModbusFrame& frame, ModbusWriteSingle& write)
+{
+    if (!frame.valid || frame.functionCode != FC_WRITE_SINGLE_REGISTER)
+    {
+        return false;
+    }
+    if (frame.dataLength != 4)
+    {
+        return false;
+    }
+
+    write.registerAddress = (static_cast<uint16_t>(frame.data[0]) << 8) | frame.data[1];
+    write.value           = (static_cast<uint16_t>(frame.data[2]) << 8) | frame.data[3];
+    return true;
+}
+
+bool parseWriteMultiple(const ModbusFrame& frame, ModbusWriteMultiple& write)
+{
+    if (!frame.valid || frame.functionCode != FC_WRITE_MULTIPLE_REGISTERS)
+    {
+        return false;
+    }
+    if (frame.dataLength < 5)
+    {
+        return false;
+    }
+
+    write.startRegister = (static_cast<uint16_t>(frame.data[0]) << 8) | frame.data[1];
+    write.quantity      = (static_cast<uint16_t>(frame.data[2]) << 8) | frame.data[3];
+    uint8_t byteCount   = frame.data[4];
+
+    if (byteCount != write.quantity * 2)
+    {
+        return false;
+    }
+    if (write.quantity > 50)
+    {
+        return false;
+    }
+    if (frame.dataLength != static_cast<uint8_t>(5 + byteCount))
+    {
+        return false;
+    }
+
+    for (uint16_t i = 0; i < write.quantity; i++)
+    {
+        write.values[i] = (static_cast<uint16_t>(frame.data[5 + i * 2]) << 8) | frame.data[6 + i * 2];
+    }
+
+    return true;
+}
+
+uint8_t buildReadRequest(uint8_t slaveAddr, uint16_t startReg, uint16_t qty, uint8_t* buffer)
+{
+    buffer[0] = slaveAddr;
+    buffer[1] = FC_READ_HOLDING_REGISTERS;
+    buffer[2] = static_cast<uint8_t>(startReg >> 8);
+    buffer[3] = static_cast<uint8_t>(startReg & 0xFF);
+    buffer[4] = static_cast<uint8_t>(qty >> 8);
+    buffer[5] = static_cast<uint8_t>(qty & 0xFF);
+
+    uint16_t crc = modbusRtuCrc16(buffer, 6);
+    buffer[6] = static_cast<uint8_t>(crc & 0xFF);
+    buffer[7] = static_cast<uint8_t>(crc >> 8);
+    return 8;
+}
+
+uint8_t buildWriteSingle(uint8_t slaveAddr, uint16_t reg, uint16_t value, uint8_t* buffer)
+{
+    buffer[0] = slaveAddr;
+    buffer[1] = FC_WRITE_SINGLE_REGISTER;
+    buffer[2] = static_cast<uint8_t>(reg >> 8);
+    buffer[3] = static_cast<uint8_t>(reg & 0xFF);
+    buffer[4] = static_cast<uint8_t>(value >> 8);
+    buffer[5] = static_cast<uint8_t>(value & 0xFF);
+
+    uint16_t crc = modbusRtuCrc16(buffer, 6);
+    buffer[6] = static_cast<uint8_t>(crc & 0xFF);
+    buffer[7] = static_cast<uint8_t>(crc >> 8);
+    return 8;
+}
+
+uint8_t buildWriteMultiple(uint8_t slaveAddr, uint16_t startReg, uint16_t qty, const uint16_t* values, uint8_t* buffer)
+{
+    buffer[0] = slaveAddr;
+    buffer[1] = FC_WRITE_MULTIPLE_REGISTERS;
+    buffer[2] = static_cast<uint8_t>(startReg >> 8);
+    buffer[3] = static_cast<uint8_t>(startReg & 0xFF);
+    buffer[4] = static_cast<uint8_t>(qty >> 8);
+    buffer[5] = static_cast<uint8_t>(qty & 0xFF);
+    buffer[6] = static_cast<uint8_t>(qty * 2);
+
+    for (uint16_t i = 0; i < qty; i++)
+    {
+        buffer[7 + i * 2] = static_cast<uint8_t>(values[i] >> 8);
+        buffer[8 + i * 2] = static_cast<uint8_t>(values[i] & 0xFF);
+    }
+
+    uint8_t  frameLen = 7 + qty * 2;
+    uint16_t crc      = modbusRtuCrc16(buffer, frameLen);
+    buffer[frameLen]     = static_cast<uint8_t>(crc & 0xFF);
+    buffer[frameLen + 1] = static_cast<uint8_t>(crc >> 8);
+    return frameLen + 2;
+}
+
+}  // namespace aquamqtt::message::optitronic2

--- a/AquaMQTT/platformio.ini
+++ b/AquaMQTT/platformio.ini
@@ -26,6 +26,7 @@ lib_deps =
     SPI@3.0.5
     https://github.com/denyssene/SimpleKalmanFilter.git#v0.2
     ArduinoJSON@7.2.0
+    esp32async/ESPAsyncWebServer@^3.7.4
 
 [env:native]
 platform = native
@@ -42,6 +43,8 @@ board = arduino_nano_esp32
 
 [env:esp32-s3-devkitc-1]
 framework = arduino
+upload_protocol = espota
+upload_port = 192.168.0.228
 build_flags =
     -std=c++11
     -DARDUINO_USB_CDC_ON_BOOT=1
@@ -50,3 +53,4 @@ build_flags =
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.05/platform-espressif32.zip
 board = esp32-s3-devkitc-1
 board_build.mcu = esp32s3
+board_build.filesystem = littlefs

--- a/AquaMQTT/src/config/WebConfig.cpp
+++ b/AquaMQTT/src/config/WebConfig.cpp
@@ -1,0 +1,176 @@
+#include "config/WebConfig.h"
+
+#include <ArduinoJson.h>
+#include <LittleFS.h>
+
+#include "config/Configuration.h"
+
+namespace aquamqtt
+{
+
+WifiConfig wifiConfig;
+MqttConfig mqttConfig;
+AquaMqttConfig aquaMqttConfig;
+
+static void ensureDir(const char* path)
+{
+    if (!LittleFS.exists(path))
+    {
+        LittleFS.mkdir(path);
+    }
+}
+
+static void createDefaultWifi()
+{
+    ensureDir("/config");
+    File f = LittleFS.open("/config/wifi.json", "w");
+    if (f)
+    {
+        f.print("{\"ssid\":\"");
+        f.print(config::ssid);
+        f.print("\",\"password\":\"");
+        f.print(config::psk);
+        f.print("\",\"networkName\":\"aquamqtt\"}");
+        f.close();
+    }
+}
+
+static void createDefaultMqtt()
+{
+    ensureDir("/config");
+    File f = LittleFS.open("/config/mqtt.json", "w");
+    if (f)
+    {
+        JsonDocument doc;
+        doc["server"] = config::brokerAddr;
+        doc["port"] = config::brokerPort;
+        doc["user"] = config::brokerUser;
+        doc["password"] = config::brokerPassword;
+        doc["clientId"] = config::brokerClientId;
+        doc["enableDiscovery"] = true;
+        doc["discoveryPrefix"] = "homeassistant/";
+        serializeJson(doc, f);
+        f.close();
+    }
+}
+
+static void createDefaultAquaMqtt()
+{
+    ensureDir("/config");
+    File f = LittleFS.open("/config/aquamqtt.json", "w");
+    if (f)
+    {
+        JsonDocument doc;
+        doc["heatpumpModelName"] = config::heatpumpModelName;
+        doc["operationMode"] = static_cast<int>(config::OPERATION_MODE);
+        serializeJson(doc, f);
+        f.close();
+    }
+}
+
+bool loadWifiConfig()
+{
+    File file = LittleFS.open("/config/wifi.json", "r");
+    if (!file)
+    {
+        Serial.println("[config] wifi.json not found, creating defaults");
+        createDefaultWifi();
+        file = LittleFS.open("/config/wifi.json", "r");
+        if (!file) return false;
+    }
+
+    JsonDocument doc;
+    DeserializationError err = deserializeJson(doc, file);
+    file.close();
+
+    if (err)
+    {
+        Serial.print("[config] wifi.json parse error: ");
+        Serial.println(err.c_str());
+        return false;
+    }
+
+    wifiConfig.ssid = doc["ssid"] | "";
+    wifiConfig.password = doc["password"] | "";
+    wifiConfig.networkName = doc["networkName"] | "aquamqtt";
+
+    if (wifiConfig.ssid.length() == 0)
+    {
+        Serial.println("[config] wifi SSID is empty");
+        return false;
+    }
+
+    return true;
+}
+
+bool loadMqttConfig()
+{
+    File file = LittleFS.open("/config/mqtt.json", "r");
+    if (!file)
+    {
+        Serial.println("[config] mqtt.json not found, creating defaults");
+        createDefaultMqtt();
+        file = LittleFS.open("/config/mqtt.json", "r");
+        if (!file) return false;
+    }
+
+    JsonDocument doc;
+    DeserializationError err = deserializeJson(doc, file);
+    file.close();
+
+    if (err)
+    {
+        Serial.print("[config] mqtt.json parse error: ");
+        Serial.println(err.c_str());
+        return false;
+    }
+
+    mqttConfig.server = doc["server"] | "localhost";
+    mqttConfig.port = doc["port"] | 1883;
+    mqttConfig.user = doc["user"] | "";
+    mqttConfig.password = doc["password"] | "";
+    mqttConfig.clientId = doc["clientId"] | "aquamqtt";
+    mqttConfig.enableDiscovery = doc["enableDiscovery"] | true;
+    mqttConfig.discoveryPrefix = doc["discoveryPrefix"] | "homeassistant/";
+
+    return true;
+}
+
+bool loadAquaMqttConfig()
+{
+    File file = LittleFS.open("/config/aquamqtt.json", "r");
+    if (!file)
+    {
+        Serial.println("[config] aquamqtt.json not found, creating defaults");
+        createDefaultAquaMqtt();
+        file = LittleFS.open("/config/aquamqtt.json", "r");
+        if (!file) return false;
+    }
+
+    JsonDocument doc;
+    DeserializationError err = deserializeJson(doc, file);
+    file.close();
+
+    if (err)
+    {
+        Serial.print("[config] aquamqtt.json parse error: ");
+        Serial.println(err.c_str());
+        return false;
+    }
+
+    aquaMqttConfig.heatpumpModelName = doc["heatpumpModelName"] | "Austria Email WPA 450 ECO";
+    aquaMqttConfig.operationMode = doc["operationMode"] | 3;  // OPTITRONIC2_MITM
+
+    return true;
+}
+
+bool loadAllConfig()
+{
+    bool ok = true;
+    if (!loadWifiConfig()) ok = false;
+    if (!loadMqttConfig()) ok = false;
+    if (!loadAquaMqttConfig()) ok = false;
+    return ok;
+}
+
+}  // namespace aquamqtt

--- a/AquaMQTT/src/handler/OTA.cpp
+++ b/AquaMQTT/src/handler/OTA.cpp
@@ -1,9 +1,11 @@
 #include "handler/OTA.h"
 
 #include <ArduinoOTA.h>
+#include <WiFi.h>
 #include <esp_task_wdt.h>
 
 #include "config/Configuration.h"
+#include "config/WebConfig.h"
 
 namespace aquamqtt
 {
@@ -14,7 +16,7 @@ void OTAHandler::setup()  // NOLINT(*-convert-member-functions-to-static)
     // ArduinoOTA.setPort(3232);
 
     // Hostname defaults to esp3232-[MAC]
-    ArduinoOTA.setHostname(config::networkName);
+    ArduinoOTA.setHostname(wifiConfig.networkName.c_str());
 
     // No authentication by default
     // ArduinoOTA.setPassword("admin");
@@ -53,11 +55,25 @@ void OTAHandler::setup()  // NOLINT(*-convert-member-functions-to-static)
                     Serial.println("End Failed");
             });
 
-    ArduinoOTA.begin();
+    // Don't call begin() here — WiFi may not be connected yet.
+    // begin() is called in loop() once WiFi is up.
+    mStarted = false;
 }
 
 void OTAHandler::loop()  // NOLINT(*-convert-member-functions-to-static)
 {
+    if (!mStarted)
+    {
+        // Wait until WiFi has an IP before binding OTA socket
+        if (WiFi.status() == WL_CONNECTED && WiFi.localIP() != INADDR_NONE)
+        {
+            ArduinoOTA.begin();
+            mStarted = true;
+            Serial.println("[ota] started");
+        }
+        return;
+    }
+
     ArduinoOTA.handle();
 }
 

--- a/AquaMQTT/src/handler/Web.cpp
+++ b/AquaMQTT/src/handler/Web.cpp
@@ -1,0 +1,291 @@
+#include "handler/Web.h"
+
+#include <ArduinoJson.h>
+#include <AsyncJson.h>
+#include <LittleFS.h>
+
+#include "config/WebConfig.h"
+#include "task/ModbusRelayTask.h"
+
+extern aquamqtt::ModbusRelayTask modbusRelayTask;
+
+namespace aquamqtt
+{
+
+AsyncWebServer WebHandler::mServer(80);
+
+WebHandler::WebHandler()
+{
+}
+
+void WebHandler::setup()
+{
+    // Serve static files
+    mServer.serveStatic("/web/", LittleFS, "/web/");
+
+    // Root page
+    mServer.on("/", HTTP_GET, handleRoot);
+
+    // GET API endpoints — return stored config JSON
+    mServer.on("/api/wifi", HTTP_GET, handleWifiGet);
+    mServer.on("/api/mqtt", HTTP_GET, handleMqttGet);
+    mServer.on("/api/aquamqtt", HTTP_GET, handleAquaGet);
+
+    // Reboot endpoint
+    mServer.on("/reboot", HTTP_GET, handleReboot);
+
+    // Diagnostics endpoint
+    mServer.on("/api/diag", HTTP_GET, [](AsyncWebServerRequest* request) {
+        String json = "{\"framesReceived\":";
+        json += modbusRelayTask.getFramesReceived();
+        json += ",\"crcErrors\":";
+        json += modbusRelayTask.getCrcErrors();
+        json += ",\"framesRelayed\":";
+        json += modbusRelayTask.getFramesRelayed();
+        json += ",\"hmiFramesIn\":";
+        json += modbusRelayTask.getHmiFramesIn();
+        json += ",\"mainFramesIn\":";
+        json += modbusRelayTask.getMainFramesIn();
+        json += ",\"hmiBytesIn\":";
+        json += modbusRelayTask.getHmiBytesIn();
+        json += ",\"mainBytesIn\":";
+        json += modbusRelayTask.getMainBytesIn();
+        json += ",\"echoBytes\":";
+        json += modbusRelayTask.getEchoBytes();
+        json += ",\"txBytesWritten\":";
+        json += modbusRelayTask.getTxBytesWritten();
+        json += ",\"writesInjected\":";
+        json += modbusRelayTask.getWritesInjected();
+        json += ",\"lastFrame\":\"";
+        for (int i = 0; i < modbusRelayTask.getLastFwdFrameLen(); i++) {
+            char hex[4];
+            snprintf(hex, sizeof(hex), "%02X ", modbusRelayTask.getLastFwdFrame()[i]);
+            json += hex;
+        }
+        json += "\"";
+        json += ",\"uptime\":";
+        json += millis();
+        json += "}";
+
+        request->send(200, "application/json", json);
+    });
+
+    // POST API: WiFi config
+    auto* wifiHandler = new AsyncCallbackJsonWebHandler("/api/wifi");
+    wifiHandler->setMethod(HTTP_POST);
+    wifiHandler->onRequest([](AsyncWebServerRequest* request, JsonVariant& json) {
+        JsonObject root = json.as<JsonObject>();
+        bool reboot = root["reboot"] | false;
+        JsonObject data = root["data"].as<JsonObject>();
+
+        String ssid = data["ssid"] | "";
+        if (ssid.length() == 0)
+        {
+            request->send(400, "application/json", "{\"error\":\"SSID required\"}");
+            return;
+        }
+
+        String output;
+        serializeJson(data, output);
+        if (saveConfigFile("wifi", output))
+        {
+            request->send(200, "application/json", "{\"status\":\"ok\"}");
+        }
+        else
+        {
+            request->send(500, "application/json", "{\"error\":\"write failed\"}");
+            return;
+        }
+
+        if (reboot)
+        {
+            delay(1000);
+            ESP.restart();
+        }
+    });
+
+    // POST API: MQTT config
+    auto* mqttHandler = new AsyncCallbackJsonWebHandler("/api/mqtt");
+    mqttHandler->setMethod(HTTP_POST);
+    mqttHandler->onRequest([](AsyncWebServerRequest* request, JsonVariant& json) {
+        JsonObject root = json.as<JsonObject>();
+        bool reboot = root["reboot"] | false;
+        JsonObject data = root["data"].as<JsonObject>();
+
+        String output;
+        serializeJson(data, output);
+        if (saveConfigFile("mqtt", output))
+        {
+            request->send(200, "application/json", "{\"status\":\"ok\"}");
+        }
+        else
+        {
+            request->send(500, "application/json", "{\"error\":\"write failed\"}");
+            return;
+        }
+
+        if (reboot)
+        {
+            delay(1000);
+            ESP.restart();
+        }
+    });
+
+    // POST API: AquaMQTT config
+    auto* aquaHandler = new AsyncCallbackJsonWebHandler("/api/aquamqtt");
+    aquaHandler->setMethod(HTTP_POST);
+    aquaHandler->onRequest([](AsyncWebServerRequest* request, JsonVariant& json) {
+        JsonObject root = json.as<JsonObject>();
+        bool reboot = root["reboot"] | false;
+        JsonObject data = root["data"].as<JsonObject>();
+
+        String output;
+        serializeJson(data, output);
+        if (saveConfigFile("aquamqtt", output))
+        {
+            request->send(200, "application/json", "{\"status\":\"ok\"}");
+        }
+        else
+        {
+            request->send(500, "application/json", "{\"error\":\"write failed\"}");
+            return;
+        }
+
+        if (reboot)
+        {
+            delay(1000);
+            ESP.restart();
+        }
+    });
+
+    mServer.addHandler(wifiHandler);
+    mServer.addHandler(mqttHandler);
+    mServer.addHandler(aquaHandler);
+
+    mServer.onNotFound(handleNotFound);
+    mServer.begin();
+    Serial.println("[web] server started on port 80");
+}
+
+void WebHandler::loop()
+{
+}
+
+bool WebHandler::saveConfigFile(const String& filename, const String& content)
+{
+    String path = "/config/" + filename + ".json";
+    File file = LittleFS.open(path, "w");
+    if (!file)
+    {
+        Serial.printf("[web] failed to open %s for writing\n", path.c_str());
+        return false;
+    }
+    file.print(content);
+    file.close();
+    return true;
+}
+
+void WebHandler::handleRoot(AsyncWebServerRequest* request)
+{
+    if (LittleFS.exists("/index.html"))
+    {
+        request->send(LittleFS, "/index.html", "text/html");
+    }
+    else
+    {
+        // Serve a minimal embedded page if no filesystem HTML available
+        request->send(200, "text/html",
+            "<!DOCTYPE html><html><head><meta charset='UTF-8'><meta name='viewport' content='width=device-width,initial-scale=1'>"
+            "<title>AquaMQTT Config</title><style>body{font-family:sans-serif;background:#1a1a2e;color:#e0e0e0;padding:20px;max-width:600px;margin:0 auto}"
+            "h1{color:#4fc3f7}label{display:block;margin:12px 0 4px;color:#90caf9;font-size:.85em}"
+            "input,select{width:100%;padding:8px;border:1px solid #333;border-radius:4px;background:#0f3460;color:#e0e0e0;box-sizing:border-box}"
+            ".tabs{display:flex;gap:4px;margin:20px 0}.tab{padding:8px 16px;background:#16213e;border:1px solid #333;border-radius:4px;cursor:pointer;color:#aaa}"
+            ".tab.active{background:#0f3460;color:#4fc3f7}.panel{display:none}.panel.active{display:block}"
+            ".btn{padding:10px 20px;border:none;border-radius:4px;cursor:pointer;font-weight:600;margin:4px}"
+            ".btn-save{background:#4fc3f7;color:#000}.btn-reboot{background:#ff7043;color:#fff}"
+            "#alert{padding:10px;border-radius:4px;margin:10px 0;display:none}</style></head><body>"
+            "<h1>AquaMQTT Config</h1><p style='color:#888'>Optitronic 2</p><div id='alert'></div>"
+            "<div class='tabs'><div class='tab active' data-tab='wifi'>WiFi</div><div class='tab' data-tab='mqtt'>MQTT</div><div class='tab' data-tab='aquamqtt'>Device</div></div>"
+            "<div class='panel active' id='panel-wifi'><form id='form-wifi'>"
+            "<label>SSID</label><input id='ssid' name='ssid'>"
+            "<label>Password</label><input id='password' name='password' type='password'>"
+            "<label>Network Name</label><input id='networkName' name='networkName'>"
+            "</form></div>"
+            "<div class='panel' id='panel-mqtt'><form id='form-mqtt'>"
+            "<label>Server</label><input id='server' name='server'>"
+            "<label>Port</label><input id='port' name='port' type='number'>"
+            "<label>User</label><input id='user' name='user'>"
+            "<label>Password</label><input id='mqtt_password' name='password' type='password'>"
+            "<label>Client ID</label><input id='clientId' name='clientId'>"
+            "<label><input id='enableDiscovery' name='enableDiscovery' type='checkbox'> HA Discovery</label>"
+            "<label>Discovery Prefix</label><input id='discoveryPrefix' name='discoveryPrefix'>"
+            "</form></div>"
+            "<div class='panel' id='panel-aquamqtt'><form id='form-aquamqtt'>"
+            "<label>Model Name</label><input id='heatpumpModelName' name='heatpumpModelName'>"
+            "<label>Mode</label><select id='operationMode' name='operationMode'>"
+            "<option value='0'>LISTENER</option><option value='1'>MITM</option>"
+            "<option value='2'>OPTITRONIC2_LISTENER</option><option value='3'>OPTITRONIC2_MITM</option></select>"
+            "</form></div>"
+            "<div><button class='btn btn-save' id='btn-save'>Save</button>"
+            "<button class='btn btn-reboot' id='btn-save-reboot'>Save &amp; Reboot</button></div>"
+            "<script>"
+            "document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{"
+            "document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active'));"
+            "document.querySelectorAll('.panel').forEach(x=>x.classList.remove('active'));"
+            "t.classList.add('active');document.getElementById('panel-'+t.dataset.tab).classList.add('active')});"
+            "async function load(){try{let w=await(await fetch('/api/wifi')).json();"
+            "if(w.ssid)document.getElementById('ssid').value=w.ssid;"
+            "if(w.password)document.getElementById('password').value=w.password;"
+            "if(w.networkName)document.getElementById('networkName').value=w.networkName}catch(e){}"
+            "try{let m=await(await fetch('/api/mqtt')).json();"
+            "if(m.server)document.getElementById('server').value=m.server;"
+            "if(m.port)document.getElementById('port').value=m.port;"
+            "if(m.user)document.getElementById('user').value=m.user;"
+            "if(m.password)document.getElementById('mqtt_password').value=m.password;"
+            "if(m.clientId)document.getElementById('clientId').value=m.clientId;"
+            "document.getElementById('enableDiscovery').checked=m.enableDiscovery||false;"
+            "if(m.discoveryPrefix)document.getElementById('discoveryPrefix').value=m.discoveryPrefix}catch(e){}"
+            "try{let a=await(await fetch('/api/aquamqtt')).json();"
+            "if(a.heatpumpModelName)document.getElementById('heatpumpModelName').value=a.heatpumpModelName;"
+            "if(a.operationMode!==undefined)document.getElementById('operationMode').value=a.operationMode}catch(e){}}"
+            "function getEP(){let a=document.querySelector('.tab.active');return a?a.dataset.tab:'wifi'}"
+            "function collect(ep){let f=document.getElementById('form-'+ep),d={};f.querySelectorAll('input,select').forEach(e=>{"
+            "let k=e.name||e.id;if(e.type==='checkbox')d[k]=e.checked;else if(e.type==='number'||e.tagName==='SELECT')d[k]=parseInt(e.value)||0;else d[k]=e.value});return d}"
+            "async function save(r){let ep=getEP(),d=collect(ep);try{let res=await fetch('/api/'+ep,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({reboot:r,data:d})});"
+            "let al=document.getElementById('alert');if(res.ok){al.style.display='block';al.style.background='#1b5e20';al.textContent='Saved'+(r?' - rebooting...':'')}"
+            "else{al.style.display='block';al.style.background='#b71c1c';al.textContent='Error'}}catch(e){"
+            "let al=document.getElementById('alert');al.style.display='block';al.style.background=r?'#1b5e20':'#b71c1c';al.textContent=r?'Rebooting...':'Connection error'}}"
+            "document.getElementById('btn-save').onclick=()=>save(false);"
+            "document.getElementById('btn-save-reboot').onclick=()=>save(true);load();"
+            "</script></body></html>");
+    }
+}
+
+void WebHandler::handleNotFound(AsyncWebServerRequest* request)
+{
+    request->send(404, "text/plain", "Not Found");
+}
+
+void WebHandler::handleWifiGet(AsyncWebServerRequest* request)
+{
+    request->send(LittleFS, "/config/wifi.json", "application/json");
+}
+
+void WebHandler::handleMqttGet(AsyncWebServerRequest* request)
+{
+    request->send(LittleFS, "/config/mqtt.json", "application/json");
+}
+
+void WebHandler::handleAquaGet(AsyncWebServerRequest* request)
+{
+    request->send(LittleFS, "/config/aquamqtt.json", "application/json");
+}
+
+void WebHandler::handleReboot(AsyncWebServerRequest* request)
+{
+    request->send(200, "text/plain", "Rebooting...");
+    delay(1000);
+    ESP.restart();
+}
+
+}  // namespace aquamqtt

--- a/AquaMQTT/src/handler/Wifi.cpp
+++ b/AquaMQTT/src/handler/Wifi.cpp
@@ -1,6 +1,7 @@
 #include "handler/Wifi.h"
 
 #include "config/Configuration.h"
+#include "config/WebConfig.h"
 
 namespace aquamqtt
 {
@@ -11,21 +12,34 @@ WifiHandler::WifiHandler() : mLastCheck(0)
 {
 }
 
-void WifiHandler::setup()
+void WifiHandler::setupAP()
+{
+    WiFiClass::mode(WIFI_AP);
+    WiFi.disconnect();
+    String macAddress = WiFi.softAPmacAddress();
+    macAddress.replace(":", "");
+    String apName = "aquamqtt-" + macAddress.substring(0, 4);
+    WiFi.softAP(apName.c_str());
+    Serial.print("[wifi] AP started: ");
+    Serial.println(apName);
+    Serial.print("[wifi] AP IP: ");
+    Serial.println(WiFi.softAPIP().toString().c_str());
+}
+
+bool WifiHandler::setup()
 {
     WiFiClass::mode(WIFI_STA);
 
-    // we don't trust the auto reconnect routine, as it seems there are edge cases where it does not work
     WiFi.setAutoReconnect(false);
-
-    // we trust the wifi callbacks to determine if we are properly connected or disconnected
     WiFi.onEvent(wifiCallback);
 
-    // begin a single wifi session
-    WiFi.begin(aquamqtt::config::ssid, aquamqtt::config::psk);
+    Serial.print("[wifi] connecting to SSID: ");
+    Serial.println(wifiConfig.ssid.c_str());
 
-    // perform the next wifi check in config::WIFI_RECONNECT_CYCLE_S
+    WiFi.begin(wifiConfig.ssid.c_str(), wifiConfig.password.c_str());
+
     mLastCheck = millis();
+    return true;
 }
 
 void WifiHandler::loop()

--- a/AquaMQTT/src/main.cpp
+++ b/AquaMQTT/src/main.cpp
@@ -8,18 +8,22 @@
 #include "task/ControllerTask.h"
 #include "task/HMITask.h"
 #include "task/ListenerTask.h"
+#include "task/ModbusListenerTask.h"
 #include "task/MQTTTask.h"
+#include "task/Optitronic2MQTTTask.h"
 
 using namespace aquamqtt;
 using namespace aquamqtt::config;
 
-HMITask        hmiTask;
-ControllerTask controllerTask;
-ListenerTask   listenerTask;
-MQTTTask       mqttTask;
-OTAHandler     otaHandler;
-RTCHandler     rtcHandler;
-WifiHandler    wifiHandler;
+HMITask              hmiTask;
+ControllerTask       controllerTask;
+ListenerTask         listenerTask;
+MQTTTask             mqttTask;
+ModbusListenerTask   modbusListenerTask;
+Optitronic2MQTTTask  optitronic2MqttTask;
+OTAHandler           otaHandler;
+RTCHandler           rtcHandler;
+WifiHandler          wifiHandler;
 
 esp_task_wdt_config_t twdt_config = {
     .timeout_ms     = WATCHDOG_TIMEOUT_MS,
@@ -71,7 +75,7 @@ void setup()
     }
     // if man-in-the-middle mode is set in configuration, there are two physical One-Wire USART instances
     // and AquaMQTT forwards (modified) messages from one to another
-    else
+    else if (OPERATION_MODE == MITM)
     {
         // reads 194 message from the hmi controller, writes 193, 67 and 74 to the hmi controller
         hmiTask.spawn();
@@ -79,7 +83,20 @@ void setup()
         // reads 193, 67 and 74 from the main controller, writes 194 to the main controller
         controllerTask.spawn();
     }
+    // Optitronic 2 Modbus RTU listener mode
+    else if (OPERATION_MODE == OPTITRONIC2_LISTENER)
+    {
+        // passively sniffs Modbus RTU bus, parses register values
+        modbusListenerTask.spawn();
+
+        // publishes register data to MQTT with HA discovery, handles commands
+        optitronic2MqttTask.spawn();
+    }
 
     // provide the message information via mqtt and enables overrides via mqtt
-    mqttTask.spawn();
+    // (only for Atlantic protocol modes)
+    if (OPERATION_MODE == LISTENER || OPERATION_MODE == MITM)
+    {
+        mqttTask.spawn();
+    }
 }

--- a/AquaMQTT/src/main.cpp
+++ b/AquaMQTT/src/main.cpp
@@ -1,14 +1,18 @@
 #include <Arduino.h>
+#include <LittleFS.h>
 #include <esp_task_wdt.h>
 
 #include "config/Configuration.h"
+#include "config/WebConfig.h"
 #include "handler/OTA.h"
 #include "handler/RTC.h"
+#include "handler/Web.h"
 #include "handler/Wifi.h"
 #include "task/ControllerTask.h"
 #include "task/HMITask.h"
 #include "task/ListenerTask.h"
 #include "task/ModbusListenerTask.h"
+#include "task/ModbusRelayTask.h"
 #include "task/MQTTTask.h"
 #include "task/Optitronic2MQTTTask.h"
 
@@ -20,10 +24,15 @@ ControllerTask       controllerTask;
 ListenerTask         listenerTask;
 MQTTTask             mqttTask;
 ModbusListenerTask   modbusListenerTask;
+ModbusRelayTask      modbusRelayTask;
 Optitronic2MQTTTask  optitronic2MqttTask;
 OTAHandler           otaHandler;
 RTCHandler           rtcHandler;
 WifiHandler          wifiHandler;
+WebHandler           webHandler;
+
+// Raw serial test counters (read from main loop, reported via /api/diag)
+
 
 esp_task_wdt_config_t twdt_config = {
     .timeout_ms     = WATCHDOG_TIMEOUT_MS,
@@ -35,7 +44,6 @@ void loop()
 {
     // watchdog
     esp_task_wdt_reset();
-    delay(1);
 
     // handle wifi events
     wifiHandler.loop();
@@ -45,6 +53,12 @@ void loop()
 
     // handle real-time-clock module in main thread
     rtcHandler.loop();
+
+    // handle web server
+    webHandler.loop();
+
+    // Drive relay directly from main loop (FreeRTOS task can't read Serial1)
+    modbusRelayTask.loop();
 }
 
 void setup()
@@ -53,13 +67,43 @@ void setup()
     Serial.begin(9600);
     Serial.println("REBOOT");
 
-    // initialize watchdog
+    // mount LittleFS filesystem (true = format on first use)
+    if (!LittleFS.begin(true))
+    {
+        Serial.println("[fs] LittleFS mount failed even after format");
+    }
+
+    // load configuration from filesystem
+    loadMqttConfig();
+    loadAquaMqttConfig();
+
+    // initialize watchdog EARLY (tasks need it for esp_task_wdt_add)
     esp_task_wdt_deinit();
     esp_task_wdt_init(&twdt_config);
     esp_task_wdt_add(nullptr);
 
-    // setup wifi
-    wifiHandler.setup();
+    // determine operation mode
+    EOperationMode opMode = static_cast<EOperationMode>(aquaMqttConfig.operationMode);
+
+    // Open serial ports for Optitronic2 modes (must be in main context to work)
+    if (opMode == OPTITRONIC2_MITM || opMode == OPTITRONIC2_LISTENER)
+    {
+        Serial1.begin(57600, SERIAL_8N1, config::GPIO_HMI_RX, config::GPIO_HMI_TX);
+        Serial2.begin(57600, SERIAL_8N1, config::GPIO_MAIN_RX, config::GPIO_MAIN_TX);
+        modbusRelayTask.setup();
+        Serial.println("[setup] Serial1+Serial2 opened, relay initialized");
+    }
+
+    // Now setup WiFi (may take several seconds)
+    if (!loadWifiConfig())
+    {
+        Serial.println("[setup] WiFi config not found, starting AP mode");
+        wifiHandler.setupAP();
+    }
+    else
+    {
+        wifiHandler.setup();
+    }
 
     // setup rtc module
     rtcHandler.setup();
@@ -67,35 +111,29 @@ void setup()
     // setup ota module
     otaHandler.setup();
 
-    // if listener mode is set in configuration, just read the DHW traffic from a single One-Wire USART instance
-    if (OPERATION_MODE == LISTENER)
+    // setup web server
+    webHandler.setup();
+
+    // spawn remaining tasks that depend on WiFi/MQTT
+    if (opMode == LISTENER)
     {
-        // reads 194, 193, 67 and 74 message and notifies the mqtt task
         listenerTask.spawn();
     }
-    // if man-in-the-middle mode is set in configuration, there are two physical One-Wire USART instances
-    // and AquaMQTT forwards (modified) messages from one to another
-    else if (OPERATION_MODE == MITM)
+    else if (opMode == MITM)
     {
-        // reads 194 message from the hmi controller, writes 193, 67 and 74 to the hmi controller
         hmiTask.spawn();
-
-        // reads 193, 67 and 74 from the main controller, writes 194 to the main controller
         controllerTask.spawn();
     }
-    // Optitronic 2 Modbus RTU listener mode
-    else if (OPERATION_MODE == OPTITRONIC2_LISTENER)
-    {
-        // passively sniffs Modbus RTU bus, parses register values
-        modbusListenerTask.spawn();
 
-        // publishes register data to MQTT with HA discovery, handles commands
+    // Optitronic2 MQTT task (needs WiFi but relay already running)
+    if (opMode == OPTITRONIC2_LISTENER || opMode == OPTITRONIC2_MITM)
+    {
         optitronic2MqttTask.spawn();
     }
 
     // provide the message information via mqtt and enables overrides via mqtt
     // (only for Atlantic protocol modes)
-    if (OPERATION_MODE == LISTENER || OPERATION_MODE == MITM)
+    if (opMode == LISTENER || opMode == MITM)
     {
         mqttTask.spawn();
     }

--- a/AquaMQTT/src/state/Optitronic2State.cpp
+++ b/AquaMQTT/src/state/Optitronic2State.cpp
@@ -348,6 +348,16 @@ uint16_t Optitronic2State::getAntiLegioInterval() const
     return 0;
 }
 
+uint16_t Optitronic2State::getExtSourcePriority() const
+{
+    uint16_t raw;
+    if (getRegister(REG_EXT_SOURCE_PRIORITY, raw))
+    {
+        return raw;
+    }
+    return 0;
+}
+
 // --- Statistics ---
 
 void Optitronic2State::updateStats(uint32_t framesRx, uint32_t crcErr)

--- a/AquaMQTT/src/state/Optitronic2State.cpp
+++ b/AquaMQTT/src/state/Optitronic2State.cpp
@@ -1,0 +1,379 @@
+#include "state/Optitronic2State.h"
+
+using namespace aquamqtt::message::optitronic2;
+
+namespace aquamqtt
+{
+
+Optitronic2State& Optitronic2State::getInstance()
+{
+    static Optitronic2State instance;
+    return instance;
+}
+
+Optitronic2State::Optitronic2State()
+    : mRegisters{}
+    , mRegisterValid{}
+    , mNotify(nullptr)
+    , mMutex(xSemaphoreCreateMutex())
+    , mChangeFlags(0)
+    , mStats{ 0, 0, 0, 0 }
+{
+    memset(mRegisterValid, 0, sizeof(mRegisterValid));
+}
+
+void Optitronic2State::setListener(const TaskHandle_t handle)
+{
+    if (!xSemaphoreTake(mMutex, portMAX_DELAY))
+    {
+        return;
+    }
+    mNotify = handle;
+    xSemaphoreGive(mMutex);
+}
+
+bool Optitronic2State::storeRegisters(uint16_t startReg, const uint16_t* values, uint16_t count)
+{
+    if (!xSemaphoreTake(mMutex, portMAX_DELAY))
+    {
+        return false;
+    }
+
+    bool anyChanged = false;
+    uint32_t changeFlag = 0;
+
+    for (uint16_t i = 0; i < count; i++)
+    {
+        uint16_t addr = startReg + i;
+        if (addr >= MAX_REGISTER_ADDR)
+        {
+            break;
+        }
+
+        if (!mRegisterValid[addr] || mRegisters[addr] != values[i])
+        {
+            mRegisters[addr]      = values[i];
+            mRegisterValid[addr]  = true;
+            anyChanged            = true;
+        }
+    }
+
+    if (anyChanged)
+    {
+        // Determine which change category this belongs to
+        if (startReg == REG_BLOCK2_START)
+        {
+            changeFlag = CHANGE_SENSORS;
+        }
+        else if (startReg == REG_BLOCK1_START)
+        {
+            changeFlag = CHANGE_SETTINGS | CHANGE_STATE;
+        }
+        else if (startReg == REG_INSTALLER_BLK1_START || startReg == REG_INSTALLER_BLK2_START)
+        {
+            changeFlag = CHANGE_INSTALLER;
+        }
+        else if (startReg == REG_SCHEDULE_DHW_START || startReg == REG_SCHEDULE_VENT_START)
+        {
+            changeFlag = CHANGE_SCHEDULE;
+        }
+        else
+        {
+            changeFlag = CHANGE_STATE;
+        }
+
+        mChangeFlags |= changeFlag;
+        mStats.registerUpdates++;
+        mStats.lastUpdateMs = millis();
+    }
+
+    xSemaphoreGive(mMutex);
+
+    if (anyChanged)
+    {
+        notifyListener(changeFlag);
+    }
+
+    return anyChanged;
+}
+
+bool Optitronic2State::storeSingleRegister(uint16_t reg, uint16_t value)
+{
+    uint16_t val = value;
+    return storeRegisters(reg, &val, 1);
+}
+
+bool Optitronic2State::getRegister(uint16_t reg, uint16_t& value) const
+{
+    if (reg >= MAX_REGISTER_ADDR)
+    {
+        return false;
+    }
+    if (!mRegisterValid[reg])
+    {
+        return false;
+    }
+    value = mRegisters[reg];
+    return true;
+}
+
+bool Optitronic2State::hasBlock(uint16_t startReg) const
+{
+    if (startReg >= MAX_REGISTER_ADDR)
+    {
+        return false;
+    }
+    return mRegisterValid[startReg];
+}
+
+// --- Typed accessors ---
+
+float Optitronic2State::getWaterTemp() const
+{
+    uint16_t raw;
+    if (getRegister(REG_WATER_TEMP, raw))
+    {
+        return regToTemp(raw);
+    }
+    return 0.0f;
+}
+
+float Optitronic2State::getAmbientTemp() const
+{
+    uint16_t raw;
+    if (getRegister(REG_AMBIENT_TEMP, raw))
+    {
+        return regToTemp(raw);
+    }
+    return 0.0f;
+}
+
+float Optitronic2State::getEvaporatorTemp() const
+{
+    uint16_t raw;
+    if (getRegister(REG_EVAPORATOR_TEMP, raw))
+    {
+        return regToTemp(raw);
+    }
+    return 0.0f;
+}
+
+float Optitronic2State::getDhwSetpoint() const
+{
+    uint16_t raw;
+    if (getRegister(REG_DHW_SETPOINT, raw))
+    {
+        return regToTemp(raw);
+    }
+    return 0.0f;
+}
+
+float Optitronic2State::getActiveSetpoint() const
+{
+    uint16_t raw;
+    if (getRegister(REG_ACTIVE_SETPOINT, raw))
+    {
+        return regToTemp(raw);
+    }
+    return 0.0f;
+}
+
+float Optitronic2State::getEcoDeviation() const
+{
+    uint16_t raw;
+    if (getRegister(REG_ECO_DEVIATION, raw))
+    {
+        return regToTemp(raw);
+    }
+    return 0.0f;
+}
+
+float Optitronic2State::getKomfortDeviation() const
+{
+    uint16_t raw;
+    if (getRegister(REG_KOMFORT_DEVIATION, raw))
+    {
+        return regToTemp(raw);
+    }
+    return 0.0f;
+}
+
+uint16_t Optitronic2State::getProgram() const
+{
+    uint16_t raw;
+    if (getRegister(REG_PROGRAM, raw))
+    {
+        return raw;
+    }
+    return 0;
+}
+
+uint16_t Optitronic2State::getAuxHeatMode() const
+{
+    uint16_t raw;
+    if (getRegister(REG_AUX_HEAT_MODE, raw))
+    {
+        return raw;
+    }
+    return 0;
+}
+
+uint16_t Optitronic2State::getExtInputFunction() const
+{
+    uint16_t raw;
+    if (getRegister(REG_EXT_INPUT_FUNCTION, raw))
+    {
+        return raw;
+    }
+    return 0;
+}
+
+uint16_t Optitronic2State::getOperatingState() const
+{
+    uint16_t raw;
+    if (getRegister(REG_OPERATING_STATE, raw))
+    {
+        return raw;
+    }
+    return 0;
+}
+
+bool Optitronic2State::isPvActive() const
+{
+    uint16_t raw;
+    if (getRegister(REG_PV_INPUT_STATUS, raw))
+    {
+        return raw == PV_STATUS_ACTIVE;
+    }
+    return false;
+}
+
+bool Optitronic2State::isQuickHeatActive() const
+{
+    uint16_t raw;
+    if (getRegister(REG_QUICK_HEAT_STATE, raw))
+    {
+        return message::optitronic2::isQuickHeatActive(raw);
+    }
+    return false;
+}
+
+float Optitronic2State::getQuickHeatTarget() const
+{
+    uint16_t raw;
+    if (getRegister(REG_QUICK_HEAT_STATE, raw))
+    {
+        return regToTemp(message::optitronic2::getQuickHeatTarget(raw));
+    }
+    return 0.0f;
+}
+
+bool Optitronic2State::isForceHeating() const
+{
+    uint16_t raw;
+    if (getRegister(REG_FORCE_HEATING, raw))
+    {
+        return raw != 0;
+    }
+    return false;
+}
+
+float Optitronic2State::getFrostProtectTemp() const
+{
+    uint16_t raw;
+    if (getRegister(REG_FROST_PROTECT_TEMP, raw))
+    {
+        return regToTemp(raw);
+    }
+    return 0.0f;
+}
+
+float Optitronic2State::getBivalentThreshold() const
+{
+    uint16_t raw;
+    if (getRegister(REG_BIVALENT_THRESHOLD, raw))
+    {
+        return regToTemp(raw);
+    }
+    return 0.0f;
+}
+
+float Optitronic2State::getPvTargetSetpoint() const
+{
+    uint16_t raw;
+    if (getRegister(REG_PV_TARGET_SETPOINT, raw))
+    {
+        return regToTemp(raw);
+    }
+    return 0.0f;
+}
+
+float Optitronic2State::getExtSourceMaxTemp() const
+{
+    uint16_t raw;
+    if (getRegister(REG_EXT_SOURCE_MAX_TEMP, raw))
+    {
+        return regToTemp(raw);
+    }
+    return 0.0f;
+}
+
+uint16_t Optitronic2State::getAntiLegioInterval() const
+{
+    uint16_t raw;
+    if (getRegister(REG_ANTI_LEGIO_INTERVAL, raw))
+    {
+        return raw;
+    }
+    return 0;
+}
+
+// --- Statistics ---
+
+void Optitronic2State::updateStats(uint32_t framesRx, uint32_t crcErr)
+{
+    if (!xSemaphoreTake(mMutex, portMAX_DELAY))
+    {
+        return;
+    }
+    mStats.framesReceived = framesRx;
+    mStats.crcErrors      = crcErr;
+    xSemaphoreGive(mMutex);
+}
+
+Optitronic2State::Stats Optitronic2State::getStats() const
+{
+    return mStats;
+}
+
+// --- Change tracking ---
+
+bool Optitronic2State::hasChanges() const
+{
+    return mChangeFlags != 0;
+}
+
+void Optitronic2State::clearChanges()
+{
+    if (!xSemaphoreTake(mMutex, portMAX_DELAY))
+    {
+        return;
+    }
+    mChangeFlags = 0;
+    xSemaphoreGive(mMutex);
+}
+
+uint32_t Optitronic2State::getChangeFlags() const
+{
+    return mChangeFlags;
+}
+
+void Optitronic2State::notifyListener(uint32_t changeFlag)
+{
+    if (mNotify != nullptr)
+    {
+        xTaskNotifyIndexed(mNotify, 0, changeFlag, eSetBits);
+    }
+}
+
+}  // namespace aquamqtt

--- a/AquaMQTT/src/state/Optitronic2State.cpp
+++ b/AquaMQTT/src/state/Optitronic2State.cpp
@@ -241,11 +241,31 @@ uint16_t Optitronic2State::getOperatingState() const
 bool Optitronic2State::isPvActive() const
 {
     uint16_t raw;
-    if (getRegister(REG_PV_INPUT_STATUS, raw))
+    if (getRegister(REG_COMPRESSOR_STATUS, raw))
     {
-        return raw == PV_STATUS_ACTIVE;
+        return raw == COMP_PV_ACTIVE;
     }
     return false;
+}
+
+uint16_t Optitronic2State::getHeatSource() const
+{
+    uint16_t raw;
+    if (getRegister(REG_HEAT_SOURCE_ACTIVE, raw))
+    {
+        return raw;
+    }
+    return 0;
+}
+
+uint16_t Optitronic2State::getCompressorStatus() const
+{
+    uint16_t raw;
+    if (getRegister(REG_COMPRESSOR_STATUS, raw))
+    {
+        return raw;
+    }
+    return 0;
 }
 
 bool Optitronic2State::isQuickHeatActive() const

--- a/AquaMQTT/src/task/ModbusListenerTask.cpp
+++ b/AquaMQTT/src/task/ModbusListenerTask.cpp
@@ -1,0 +1,206 @@
+#include "task/ModbusListenerTask.h"
+
+#include <esp_task_wdt.h>
+
+#include "config/Configuration.h"
+#include "state/Optitronic2State.h"
+
+using namespace aquamqtt::message::optitronic2;
+
+namespace aquamqtt
+{
+
+ModbusListenerTask::ModbusListenerTask()
+    : mFrameBuffer{}
+    , mFrameLength(0)
+    , mLastByteTime(0)
+    , mFrameInProgress(false)
+    , mPendingReadRequest(false)
+    , mPendingReadStartReg(0)
+    , mPendingReadQuantity(0)
+    , mFramesReceived(0)
+    , mCrcErrors(0)
+    , mLastStatsUpdate(0)
+{
+}
+
+void ModbusListenerTask::spawn()
+{
+    TaskHandle_t handle;
+    xTaskCreatePinnedToCore(ModbusListenerTask::innerTask, "modbusListenerLoop", 4096, this, 4, &handle, 1);
+    esp_task_wdt_add(handle);
+}
+
+[[noreturn]] void ModbusListenerTask::innerTask(void* pvParameters)
+{
+    auto* self = static_cast<ModbusListenerTask*>(pvParameters);
+
+    self->setup();
+
+    while (true)
+    {
+        esp_task_wdt_reset();
+        self->loop();
+    }
+}
+
+void ModbusListenerTask::setup()
+{
+    Serial2.begin(
+            MODBUS_BAUD_RATE,
+            SERIAL_8N1,
+            config::GPIO_MAIN_RX,
+            config::GPIO_MAIN_TX);
+}
+
+void ModbusListenerTask::loop()
+{
+    unsigned long now = millis();
+
+    // Check for inter-frame silence (frame boundary detection)
+    if (mFrameInProgress && (now - mLastByteTime) >= MODBUS_FRAME_SILENCE_MS)
+    {
+        // Frame complete — process it
+        if (mFrameLength >= 5)  // minimum valid Modbus frame
+        {
+            processFrame();
+        }
+        mFrameLength    = 0;
+        mFrameInProgress = false;
+    }
+
+    // Read available bytes from serial
+    while (Serial2.available())
+    {
+        uint8_t byte = Serial2.read();
+        now          = millis();
+
+        // If we were accumulating a frame and there was a gap, process the previous frame first
+        if (mFrameInProgress && (now - mLastByteTime) >= MODBUS_FRAME_SILENCE_MS)
+        {
+            if (mFrameLength >= 5)
+            {
+                processFrame();
+            }
+            mFrameLength    = 0;
+            mFrameInProgress = false;
+        }
+
+        // Start or continue accumulating a frame
+        if (mFrameLength < MODBUS_MAX_FRAME_SIZE)
+        {
+            mFrameBuffer[mFrameLength++] = byte;
+        }
+        mLastByteTime    = now;
+        mFrameInProgress = true;
+    }
+
+    // Periodic stats update
+    if ((now - mLastStatsUpdate) >= 5000)
+    {
+        Optitronic2State::getInstance().updateStats(mFramesReceived, mCrcErrors);
+
+        Serial.print("[modbus]: frames=");
+        Serial.print(mFramesReceived);
+        Serial.print(", crcErr=");
+        Serial.println(mCrcErrors);
+
+        mLastStatsUpdate = now;
+    }
+
+    // Small delay to prevent starving other tasks
+    vTaskDelay(pdMS_TO_TICKS(1));
+}
+
+void ModbusListenerTask::processFrame()
+{
+    ModbusFrame frame;
+
+    if (!parseModbusFrame(mFrameBuffer, mFrameLength, frame))
+    {
+        mCrcErrors++;
+        return;
+    }
+
+    mFramesReceived++;
+
+    // Only process frames for our slave address
+    if (frame.slaveAddress != MODBUS_SLAVE_ADDRESS)
+    {
+        return;
+    }
+
+    switch (frame.functionCode)
+    {
+        case FC_READ_HOLDING_REGISTERS:
+        {
+            // Determine if this is a request (4 data bytes) or response (has byte count)
+            if (frame.dataLength == 4)
+            {
+                // This is a master READ REQUEST: [startHi, startLo, qtyHi, qtyLo]
+                ModbusReadRequest request;
+                if (parseReadRequest(frame, request))
+                {
+                    mPendingReadRequest  = true;
+                    mPendingReadStartReg = request.startRegister;
+                    mPendingReadQuantity = request.quantity;
+                }
+            }
+            else if (frame.dataLength >= 3 && mPendingReadRequest)
+            {
+                // This is a slave READ RESPONSE: [byteCount, data...]
+                ModbusReadResponse response;
+                if (parseReadResponse(frame, response))
+                {
+                    // Validate response matches our pending request
+                    if (response.registerCount == mPendingReadQuantity)
+                    {
+                        // Store register values in state
+                        Optitronic2State::getInstance().storeRegisters(
+                                mPendingReadStartReg, response.registers, response.registerCount);
+                    }
+                }
+                mPendingReadRequest = false;
+            }
+            break;
+        }
+
+        case FC_WRITE_SINGLE_REGISTER:
+        {
+            // Both request and response have same format: [regHi, regLo, valHi, valLo]
+            ModbusWriteSingle write;
+            if (parseWriteSingle(frame, write))
+            {
+                // Store the written value
+                Optitronic2State::getInstance().storeSingleRegister(write.registerAddress, write.value);
+            }
+            // A write clears any pending read request context
+            mPendingReadRequest = false;
+            break;
+        }
+
+        case FC_WRITE_MULTIPLE_REGISTERS:
+        {
+            // Master request: [startHi, startLo, qtyHi, qtyLo, byteCount, data...]
+            if (frame.dataLength > 5)
+            {
+                ModbusWriteMultiple write;
+                if (parseWriteMultiple(frame, write))
+                {
+                    Optitronic2State::getInstance().storeRegisters(
+                            write.startRegister, write.values, write.quantity);
+                }
+            }
+            // Response for fn=0x10 is just [startHi, startLo, qtyHi, qtyLo] (4 bytes) — ignore
+            mPendingReadRequest = false;
+            break;
+        }
+
+        default:
+            // Unknown function code — ignore
+            mPendingReadRequest = false;
+            break;
+    }
+}
+
+}  // namespace aquamqtt

--- a/AquaMQTT/src/task/ModbusListenerTask.cpp
+++ b/AquaMQTT/src/task/ModbusListenerTask.cpp
@@ -20,6 +20,8 @@ ModbusListenerTask::ModbusListenerTask()
     , mPendingReadQuantity(0)
     , mFramesReceived(0)
     , mCrcErrors(0)
+    , mRawBytesReceived(0)
+    , mRawBytesHmi(0)
     , mLastStatsUpdate(0)
 {
 }
@@ -73,6 +75,7 @@ void ModbusListenerTask::loop()
     while (Serial2.available())
     {
         uint8_t byte = Serial2.read();
+        mRawBytesReceived++;
         now          = millis();
 
         // If we were accumulating a frame and there was a gap, process the previous frame first

--- a/AquaMQTT/src/task/ModbusRelayTask.cpp
+++ b/AquaMQTT/src/task/ModbusRelayTask.cpp
@@ -1,0 +1,460 @@
+#include "task/ModbusRelayTask.h"
+
+#include <esp_task_wdt.h>
+#include <driver/gpio.h>
+#include <esp_rom_gpio.h>
+#include <soc/uart_periph.h>
+
+#include "config/Configuration.h"
+#include "state/Optitronic2State.h"
+#include "task/Optitronic2MQTTTask.h"
+
+using namespace aquamqtt::message::optitronic2;
+
+// External reference to MQTT task for write dequeue
+extern aquamqtt::Optitronic2MQTTTask optitronic2MqttTask;
+
+namespace aquamqtt
+{
+
+ModbusRelayTask::ModbusRelayTask()
+    : mHmiFrameBuffer{}
+    , mHmiFrameLength(0)
+    , mHmiLastByteTime(0)
+    , mHmiFrameInProgress(false)
+    , mMainFrameBuffer{}
+    , mMainFrameLength(0)
+    , mMainLastByteTime(0)
+    , mMainFrameInProgress(false)
+    , mPendingReadRequest(false)
+    , mPendingReadStartReg(0)
+    , mPendingReadQuantity(0)
+    , mFramesReceived(0)
+    , mCrcErrors(0)
+    , mFramesRelayed(0)
+    , mWritesInjected(0)
+    , mHmiFramesIn(0)
+    , mMainFramesIn(0)
+    , mHmiBytesIn(0)
+    , mMainBytesIn(0)
+    , mLastStatsUpdate(0)
+    , mEchoBytes(0)
+    , mTxBytesWritten(0)
+    , mLastFwdFrame{}
+    , mLastFwdFrameLen(0)
+{
+}
+
+void ModbusRelayTask::spawn()
+{
+    TaskHandle_t handle;
+    xTaskCreatePinnedToCore(ModbusRelayTask::innerTask, "modbusRelayLoop", 8192, this, 5, &handle, 1);
+    // Don't register with WDT for now — testing if WDT kills the task
+}
+
+[[noreturn]] void ModbusRelayTask::innerTask(void* pvParameters)
+{
+    auto* self = static_cast<ModbusRelayTask*>(pvParameters);
+
+    self->setup();
+
+    while (true)
+    {
+        self->loop();
+    }
+}
+
+void ModbusRelayTask::setup()
+{
+    // Serials already opened from main setup()
+    // TX enable pins: HIGH=transmit, LOW=receive
+    pinMode(config::GPIO_ENABLE_TX_HMI, OUTPUT);
+    pinMode(config::GPIO_ENABLE_TX_MAIN, OUTPUT);
+    digitalWrite(config::GPIO_ENABLE_TX_HMI, LOW);    // receive from HMI
+    digitalWrite(config::GPIO_ENABLE_TX_MAIN, LOW);    // receive from Main
+
+    // === ONE-WIRE UART: Fully disconnect TX pins during receive ===
+    // The SN74LVC2T45 in receive mode (DIR=LOW) makes B-side inputs, A-side outputs.
+    // The translator drives A1 (our TX pin) with bus data. If ESP's UART TX also drives
+    // this pin, there's bus contention. Fix: disconnect UART TX output from pin entirely.
+    // Route to SIG_GPIO_OUT_IDX (constant HIGH, pin not driven by peripheral)
+    // Actually: just set pin as input and disconnect output signal
+    gpio_set_direction((gpio_num_t)config::GPIO_MAIN_TX, GPIO_MODE_INPUT);
+    gpio_set_direction((gpio_num_t)config::GPIO_HMI_TX, GPIO_MODE_INPUT);
+    // Disconnect any output signal from these pins
+    esp_rom_gpio_connect_out_signal(config::GPIO_MAIN_TX, SIG_GPIO_OUT_IDX, false, false);
+    esp_rom_gpio_connect_out_signal(config::GPIO_HMI_TX, SIG_GPIO_OUT_IDX, false, false);
+
+    // Also disconnect RX pins from output (they should only be inputs)
+    // The UART RX input is still connected via gpio_connect_in_signal from Serial.begin()
+    gpio_set_direction((gpio_num_t)config::GPIO_MAIN_RX, GPIO_MODE_INPUT);
+    gpio_set_direction((gpio_num_t)config::GPIO_HMI_RX, GPIO_MODE_INPUT);
+
+    Serial.println("[relay] setup complete");
+}
+
+void ModbusRelayTask::loop()
+{
+    unsigned long now = millis();
+
+    // ===== HMI side: receive frames from HMI controller =====
+    if (mHmiFrameInProgress && (now - mHmiLastByteTime) >= MODBUS_FRAME_SILENCE_MS)
+    {
+        if (mHmiFrameLength >= 5)
+        {
+            processAndForward(mHmiFrameBuffer, mHmiFrameLength, Serial2, true);
+        }
+        mHmiFrameLength     = 0;
+        mHmiFrameInProgress = false;
+    }
+
+    while (Serial1.available())
+    {
+        uint8_t byte = Serial1.read();
+        mHmiBytesIn++;
+        now = millis();
+
+        if (mHmiFrameInProgress && (now - mHmiLastByteTime) >= MODBUS_FRAME_SILENCE_MS)
+        {
+            if (mHmiFrameLength >= 5)
+            {
+                processAndForward(mHmiFrameBuffer, mHmiFrameLength, Serial2, true);
+            }
+            mHmiFrameLength     = 0;
+            mHmiFrameInProgress = false;
+        }
+
+        if (mHmiFrameLength < MODBUS_MAX_FRAME_SIZE)
+        {
+            mHmiFrameBuffer[mHmiFrameLength++] = byte;
+        }
+        mHmiLastByteTime    = now;
+        mHmiFrameInProgress = true;
+    }
+
+    // ===== Main controller side: receive frames from Main controller =====
+    if (mMainFrameInProgress && (now - mMainLastByteTime) >= MODBUS_FRAME_SILENCE_MS)
+    {
+        if (mMainFrameLength >= 5)
+        {
+            processAndForward(mMainFrameBuffer, mMainFrameLength, Serial1, false);
+        }
+        mMainFrameLength     = 0;
+        mMainFrameInProgress = false;
+    }
+
+    while (Serial2.available())
+    {
+        uint8_t byte = Serial2.read();
+        mMainBytesIn++;
+        now = millis();
+
+        if (mMainFrameInProgress && (now - mMainLastByteTime) >= MODBUS_FRAME_SILENCE_MS)
+        {
+            if (mMainFrameLength >= 5)
+            {
+                processAndForward(mMainFrameBuffer, mMainFrameLength, Serial1, false);
+            }
+            mMainFrameLength     = 0;
+            mMainFrameInProgress = false;
+        }
+
+        if (mMainFrameLength < MODBUS_MAX_FRAME_SIZE)
+        {
+            mMainFrameBuffer[mMainFrameLength++] = byte;
+        }
+        mMainLastByteTime    = now;
+        mMainFrameInProgress = true;
+    }
+
+    // ===== Inject pending MQTT write commands during bus idle =====
+    if (!mHmiFrameInProgress && !mMainFrameInProgress)
+    {
+        injectPendingWrites();
+    }
+
+    // ===== Periodic stats update =====
+    if ((now - mLastStatsUpdate) >= 5000)
+    {
+        Optitronic2State::getInstance().updateStats(mFramesReceived, mCrcErrors);
+        mLastStatsUpdate = now;
+    }
+}
+
+void ModbusRelayTask::processAndForward(uint8_t* buffer, uint8_t length, HardwareSerial& destination, bool fromHmi)
+{
+    // Count per-side incoming frames
+    if (fromHmi) mHmiFramesIn++;
+    else mMainFramesIn++;
+
+    // Save last forwarded frame for debugging
+    mLastFwdFrameLen = min((uint8_t)32, length);
+    memcpy(mLastFwdFrame, buffer, mLastFwdFrameLen);
+
+    // Parse the frame for state extraction
+    parseFrame(buffer, length, fromHmi);
+
+    // Determine pins and UART number for the destination side
+    uint8_t txEnablePin;
+    uint8_t rxPin;
+    int     uartNum;
+
+    if (fromHmi)
+    {
+        // Forwarding toward Main (Serial2 = UART2)
+        txEnablePin = config::GPIO_ENABLE_TX_MAIN;
+        rxPin       = config::GPIO_MAIN_RX;  // GPIO 5, connected to SN74LVC2T45 A2
+        uartNum     = 2;
+    }
+    else
+    {
+        // Forwarding toward HMI (Serial1 = UART1)
+        txEnablePin = config::GPIO_ENABLE_TX_HMI;
+        rxPin       = config::GPIO_HMI_RX;   // GPIO 7, connected to SN74LVC2T45 A2
+        uartNum     = 1;
+    }
+
+    // === ONE-WIRE UART FIX ===
+    // The SN74LVC2T45 has BOTH B1 and B2 connected to the same one-wire bus.
+    // When DIR=HIGH (transmit mode, A→B): A1 drives B1, A2 drives B2.
+    // When DIR=LOW (receive mode, B→A): B drives through to A1 and A2.
+    //
+    // Problem 1: During TX, if A2 (RX pin) isn't driven with TX signal, B1≠B2 = contention
+    // Problem 2: During RX, if UART TX output still drives A1, it fights the translator
+    //
+    // Solution: 
+    //   TX mode: connect UART TX signal to BOTH A1 (txPin) and A2 (rxPin)
+    //   RX mode: disconnect all output signals, pins are pure inputs
+    int txSignal = uart_periph_signal[uartNum].pins[SOC_UART_TX_PIN_IDX].signal;
+    int rxSignal = uart_periph_signal[uartNum].pins[SOC_UART_RX_PIN_IDX].signal;
+    uint8_t txPin = fromHmi ? config::GPIO_MAIN_TX : config::GPIO_HMI_TX;
+
+    // Connect UART TX output to TX pin (A1)
+    gpio_set_direction((gpio_num_t)txPin, GPIO_MODE_OUTPUT);
+    esp_rom_gpio_connect_out_signal(txPin, txSignal, false, false);
+
+    // Connect UART TX output to RX pin (A2) — both pins carry same data
+    gpio_set_direction((gpio_num_t)rxPin, GPIO_MODE_INPUT_OUTPUT);
+    esp_rom_gpio_connect_out_signal(rxPin, txSignal, false, false);
+
+    // Small delay for GPIO matrix and translator to settle
+    delayMicroseconds(10);
+
+    // Enable transmit direction on level translator (DIR=HIGH → A→B)
+    digitalWrite(txEnablePin, HIGH);
+
+    // Send frame
+    size_t written = destination.write(buffer, length);
+    destination.flush();
+    mTxBytesWritten += written;
+
+    // Back to receive mode (DIR=LOW → B→A)
+    digitalWrite(txEnablePin, LOW);
+
+    // Fully disconnect TX pin from UART output (prevent fighting translator)
+    esp_rom_gpio_connect_out_signal(txPin, SIG_GPIO_OUT_IDX, false, false);
+    gpio_set_direction((gpio_num_t)txPin, GPIO_MODE_INPUT);
+
+    // Restore RX pin as UART RX input
+    esp_rom_gpio_connect_out_signal(rxPin, SIG_GPIO_OUT_IDX, false, false);
+    gpio_set_direction((gpio_num_t)rxPin, GPIO_MODE_INPUT);
+    esp_rom_gpio_connect_in_signal(rxPin, rxSignal, false);
+
+    // Clear any echo bytes that appeared in RX buffer during transmit
+    delayMicroseconds(200);
+    while (destination.available()) { destination.read(); mEchoBytes++; }
+
+    mFramesRelayed++;
+}
+
+void ModbusRelayTask::parseFrame(uint8_t* buffer, uint8_t length, bool fromHmi)
+{
+    ModbusFrame frame;
+
+    if (!parseModbusFrame(buffer, length, frame))
+    {
+        mCrcErrors++;
+        return;
+    }
+
+    mFramesReceived++;
+
+    if (frame.slaveAddress != MODBUS_SLAVE_ADDRESS)
+    {
+        return;
+    }
+
+    switch (frame.functionCode)
+    {
+        case FC_READ_HOLDING_REGISTERS:
+        {
+            if (frame.dataLength == 4 && fromHmi)
+            {
+                // HMI read request
+                ModbusReadRequest request;
+                if (parseReadRequest(frame, request))
+                {
+                    mPendingReadRequest  = true;
+                    mPendingReadStartReg = request.startRegister;
+                    mPendingReadQuantity = request.quantity;
+                }
+            }
+            else if (frame.dataLength >= 3 && !fromHmi && mPendingReadRequest)
+            {
+                // Main controller read response
+                ModbusReadResponse response;
+                if (parseReadResponse(frame, response))
+                {
+                    if (response.registerCount == mPendingReadQuantity)
+                    {
+                        Optitronic2State::getInstance().storeRegisters(
+                                mPendingReadStartReg, response.registers, response.registerCount);
+                    }
+                }
+                mPendingReadRequest = false;
+            }
+            break;
+        }
+
+        case FC_WRITE_SINGLE_REGISTER:
+        {
+            ModbusWriteSingle write;
+            if (parseWriteSingle(frame, write))
+            {
+                Optitronic2State::getInstance().storeSingleRegister(write.registerAddress, write.value);
+            }
+            mPendingReadRequest = false;
+            break;
+        }
+
+        case FC_WRITE_MULTIPLE_REGISTERS:
+        {
+            if (frame.dataLength > 5)
+            {
+                ModbusWriteMultiple write;
+                if (parseWriteMultiple(frame, write))
+                {
+                    Optitronic2State::getInstance().storeRegisters(
+                            write.startRegister, write.values, write.quantity);
+                }
+            }
+            mPendingReadRequest = false;
+            break;
+        }
+
+        default:
+            break;
+    }
+}
+
+void ModbusRelayTask::injectPendingWrites()
+{
+    uint16_t reg;
+    uint16_t value;
+
+    if (!optitronic2MqttTask.hasPendingWrite())
+    {
+        return;
+    }
+
+    if (!optitronic2MqttTask.dequeuePendingWrite(reg, value))
+    {
+        return;
+    }
+
+    // Build a Modbus write single register frame (fn=0x06) as master → slave
+    uint8_t frame[8];
+    frame[0] = MODBUS_SLAVE_ADDRESS;
+    frame[1] = FC_WRITE_SINGLE_REGISTER;
+    frame[2] = (reg >> 8) & 0xFF;
+    frame[3] = reg & 0xFF;
+    frame[4] = (value >> 8) & 0xFF;
+    frame[5] = value & 0xFF;
+
+    // Calculate CRC-16/Modbus
+    uint16_t crc = 0xFFFF;
+    for (uint8_t i = 0; i < 6; i++)
+    {
+        crc ^= frame[i];
+        for (uint8_t b = 0; b < 8; b++)
+        {
+            if (crc & 0x0001)
+            {
+                crc >>= 1;
+                crc ^= 0xA001;
+            }
+            else
+            {
+                crc >>= 1;
+            }
+        }
+    }
+    frame[6] = crc & 0xFF;
+    frame[7] = (crc >> 8) & 0xFF;
+
+    // === ONE-WIRE UART: Connect TX signal to both pins before transmitting ===
+    int txSignal = uart_periph_signal[2].pins[SOC_UART_TX_PIN_IDX].signal;
+    int rxSignal = uart_periph_signal[2].pins[SOC_UART_RX_PIN_IDX].signal;
+
+    gpio_set_direction((gpio_num_t)config::GPIO_MAIN_TX, GPIO_MODE_OUTPUT);
+    esp_rom_gpio_connect_out_signal(config::GPIO_MAIN_TX, txSignal, false, false);
+    gpio_set_direction((gpio_num_t)config::GPIO_MAIN_RX, GPIO_MODE_INPUT_OUTPUT);
+    esp_rom_gpio_connect_out_signal(config::GPIO_MAIN_RX, txSignal, false, false);
+    delayMicroseconds(10);
+
+    // Ensure inter-frame silence before injecting
+    vTaskDelay(pdMS_TO_TICKS(3));
+
+    // Enable translator transmit direction
+    digitalWrite(config::GPIO_ENABLE_TX_MAIN, HIGH);
+
+    // Send write frame
+    Serial2.write(frame, 8);
+    Serial2.flush();
+
+    // Back to receive mode
+    digitalWrite(config::GPIO_ENABLE_TX_MAIN, LOW);
+
+    // Disconnect TX pins, restore RX input
+    esp_rom_gpio_connect_out_signal(config::GPIO_MAIN_TX, SIG_GPIO_OUT_IDX, false, false);
+    gpio_set_direction((gpio_num_t)config::GPIO_MAIN_TX, GPIO_MODE_INPUT);
+    esp_rom_gpio_connect_out_signal(config::GPIO_MAIN_RX, SIG_GPIO_OUT_IDX, false, false);
+    gpio_set_direction((gpio_num_t)config::GPIO_MAIN_RX, GPIO_MODE_INPUT);
+    esp_rom_gpio_connect_in_signal(config::GPIO_MAIN_RX, rxSignal, false);
+
+    // Clear echo bytes
+    delayMicroseconds(200);
+    while (Serial2.available()) { Serial2.read(); mEchoBytes++; }
+
+    mWritesInjected++;
+
+    Serial.printf("[relay] WRITE reg=0x%04X val=0x%04X\n", reg, value);
+
+    // Wait for response from slave (up to 50ms)
+    unsigned long start = millis();
+    while ((millis() - start) < 50)
+    {
+        if (Serial2.available())
+        {
+            uint8_t respBuf[16];
+            uint8_t respLen = 0;
+            unsigned long lastByte = millis();
+            while ((millis() - lastByte) < MODBUS_FRAME_SILENCE_MS && respLen < 16)
+            {
+                if (Serial2.available())
+                {
+                    respBuf[respLen++] = Serial2.read();
+                    lastByte = millis();
+                }
+            }
+            if (respLen >= 5)
+            {
+                parseFrame(respBuf, respLen, false);
+            }
+            break;
+        }
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
+}
+
+}  // namespace aquamqtt

--- a/AquaMQTT/src/task/ModbusRelayTask.cpp
+++ b/AquaMQTT/src/task/ModbusRelayTask.cpp
@@ -40,6 +40,8 @@ ModbusRelayTask::ModbusRelayTask()
     , mLastStatsUpdate(0)
     , mEchoBytes(0)
     , mTxBytesWritten(0)
+    , mLastPeriodicRead(0)
+    , mPeriodicReadIndex(0)
     , mLastFwdFrame{}
     , mLastFwdFrameLen(0)
 {
@@ -171,6 +173,7 @@ void ModbusRelayTask::loop()
     if (!mHmiFrameInProgress && !mMainFrameInProgress)
     {
         injectPendingWrites();
+        injectPeriodicReads();
     }
 
     // ===== Periodic stats update =====
@@ -371,30 +374,35 @@ void ModbusRelayTask::injectPendingWrites()
     frame[4] = (value >> 8) & 0xFF;
     frame[5] = value & 0xFF;
 
-    // Calculate CRC-16/Modbus
     uint16_t crc = 0xFFFF;
     for (uint8_t i = 0; i < 6; i++)
     {
         crc ^= frame[i];
         for (uint8_t b = 0; b < 8; b++)
         {
-            if (crc & 0x0001)
-            {
-                crc >>= 1;
-                crc ^= 0xA001;
-            }
-            else
-            {
-                crc >>= 1;
-            }
+            crc = (crc & 1) ? ((crc >> 1) ^ 0xA001) : (crc >> 1);
         }
     }
     frame[6] = crc & 0xFF;
     frame[7] = (crc >> 8) & 0xFF;
 
-    // === ONE-WIRE UART: Connect TX signal to both pins before transmitting ===
+    sendToMain(frame, 8);
+    mWritesInjected++;
+
+    Serial.printf("[relay] WRITE reg=0x%04X val=0x%04X\n", reg, value);
+
+    // Wait for response from slave
+    uint8_t respBuf[16];
+    int respLen = receiveFromMain(respBuf, sizeof(respBuf), 50);
+    if (respLen >= 5)
+    {
+        parseFrame(respBuf, respLen, false);
+    }
+}
+
+void ModbusRelayTask::sendToMain(uint8_t* frame, uint8_t len)
+{
     int txSignal = uart_periph_signal[2].pins[SOC_UART_TX_PIN_IDX].signal;
-    int rxSignal = uart_periph_signal[2].pins[SOC_UART_RX_PIN_IDX].signal;
 
     gpio_set_direction((gpio_num_t)config::GPIO_MAIN_TX, GPIO_MODE_OUTPUT);
     esp_rom_gpio_connect_out_signal(config::GPIO_MAIN_TX, txSignal, false, false);
@@ -402,59 +410,105 @@ void ModbusRelayTask::injectPendingWrites()
     esp_rom_gpio_connect_out_signal(config::GPIO_MAIN_RX, txSignal, false, false);
     delayMicroseconds(10);
 
-    // Ensure inter-frame silence before injecting
     vTaskDelay(pdMS_TO_TICKS(3));
-
-    // Enable translator transmit direction
     digitalWrite(config::GPIO_ENABLE_TX_MAIN, HIGH);
-
-    // Send write frame
-    Serial2.write(frame, 8);
+    Serial2.write(frame, len);
     Serial2.flush();
-
-    // Back to receive mode
     digitalWrite(config::GPIO_ENABLE_TX_MAIN, LOW);
 
-    // Disconnect TX pins, restore RX input
+    int rxSignal = uart_periph_signal[2].pins[SOC_UART_RX_PIN_IDX].signal;
     esp_rom_gpio_connect_out_signal(config::GPIO_MAIN_TX, SIG_GPIO_OUT_IDX, false, false);
     gpio_set_direction((gpio_num_t)config::GPIO_MAIN_TX, GPIO_MODE_INPUT);
     esp_rom_gpio_connect_out_signal(config::GPIO_MAIN_RX, SIG_GPIO_OUT_IDX, false, false);
     gpio_set_direction((gpio_num_t)config::GPIO_MAIN_RX, GPIO_MODE_INPUT);
     esp_rom_gpio_connect_in_signal(config::GPIO_MAIN_RX, rxSignal, false);
 
-    // Clear echo bytes
     delayMicroseconds(200);
     while (Serial2.available()) { Serial2.read(); mEchoBytes++; }
+}
 
-    mWritesInjected++;
-
-    Serial.printf("[relay] WRITE reg=0x%04X val=0x%04X\n", reg, value);
-
-    // Wait for response from slave (up to 50ms)
+int ModbusRelayTask::receiveFromMain(uint8_t* buf, uint8_t maxLen, uint16_t timeoutMs)
+{
+    int received = 0;
     unsigned long start = millis();
-    while ((millis() - start) < 50)
+    unsigned long lastByte = start;
+
+    while ((millis() - start) < timeoutMs && received < maxLen)
     {
         if (Serial2.available())
         {
-            uint8_t respBuf[16];
-            uint8_t respLen = 0;
-            unsigned long lastByte = millis();
-            while ((millis() - lastByte) < MODBUS_FRAME_SILENCE_MS && respLen < 16)
-            {
-                if (Serial2.available())
-                {
-                    respBuf[respLen++] = Serial2.read();
-                    lastByte = millis();
-                }
-            }
-            if (respLen >= 5)
-            {
-                parseFrame(respBuf, respLen, false);
-            }
-            break;
+            buf[received++] = Serial2.read();
+            lastByte = millis();
         }
-        vTaskDelay(pdMS_TO_TICKS(1));
+        else if (received > 0 && (millis() - lastByte) >= MODBUS_FRAME_SILENCE_MS)
+        {
+            break;  // frame complete
+        }
     }
+    return received;
+}
+
+void ModbusRelayTask::injectPeriodicReads()
+{
+    unsigned long now = millis();
+
+    // Poll installer blocks every 30 seconds
+    if ((now - mLastPeriodicRead) < 30000)
+    {
+        return;
+    }
+
+    // Rotate through read blocks
+    static const struct { uint16_t startReg; uint16_t qty; } blocks[] = {
+        { REG_INSTALLER_BLK1_START, REG_INSTALLER_BLK1_COUNT },
+        { REG_INSTALLER_BLK2_START, REG_INSTALLER_BLK2_COUNT },
+        { REG_SCHEDULE_DHW_START,   REG_SCHEDULE_DHW_COUNT },
+        { REG_SCHEDULE_VENT_START,  REG_SCHEDULE_VENT_COUNT },
+    };
+
+    uint8_t idx = mPeriodicReadIndex % 4;
+    uint16_t startReg = blocks[idx].startReg;
+    uint16_t qty      = blocks[idx].qty;
+
+    // Build Modbus read request: slave=0x01, FC=0x03
+    uint8_t frame[8];
+    frame[0] = MODBUS_SLAVE_ADDRESS;
+    frame[1] = FC_READ_HOLDING_REGISTERS;
+    frame[2] = (startReg >> 8) & 0xFF;
+    frame[3] = startReg & 0xFF;
+    frame[4] = (qty >> 8) & 0xFF;
+    frame[5] = qty & 0xFF;
+
+    uint16_t crc = 0xFFFF;
+    for (uint8_t i = 0; i < 6; i++)
+    {
+        crc ^= frame[i];
+        for (uint8_t b = 0; b < 8; b++)
+        {
+            crc = (crc & 1) ? ((crc >> 1) ^ 0xA001) : (crc >> 1);
+        }
+    }
+    frame[6] = crc & 0xFF;
+    frame[7] = (crc >> 8) & 0xFF;
+
+    // Track as pending read so response gets parsed
+    mPendingReadRequest  = true;
+    mPendingReadStartReg = startReg;
+    mPendingReadQuantity = qty;
+
+    sendToMain(frame, 8);
+
+    // Wait for response
+    uint8_t respBuf[128];
+    int respLen = receiveFromMain(respBuf, sizeof(respBuf), 100);
+    if (respLen >= 5)
+    {
+        parseFrame(respBuf, respLen, false);
+    }
+    mPendingReadRequest = false;
+
+    mPeriodicReadIndex++;
+    mLastPeriodicRead = now;
 }
 
 }  // namespace aquamqtt

--- a/AquaMQTT/src/task/Optitronic2MQTTTask.cpp
+++ b/AquaMQTT/src/task/Optitronic2MQTTTask.cpp
@@ -6,6 +6,7 @@
 
 #include "Version.h"
 #include "config/Configuration.h"
+#include "config/WebConfig.h"
 #include "message/optitronic2/RegisterMap.h"
 #include "state/Optitronic2State.h"
 
@@ -59,6 +60,15 @@ constexpr char CTRL_FORCE_HEAT[]    = "ctrl/forceHeating";
 constexpr char CTRL_QUICK_HEAT[]    = "ctrl/quickHeat";
 constexpr char CTRL_ANTI_LEGIO[]    = "ctrl/triggerAntiLegionella";
 constexpr char CTRL_RESET[]         = "ctrl/reset";
+constexpr char CTRL_ECO_DEV[]       = "ctrl/ecoDeviation";
+constexpr char CTRL_KOMF_DEV[]      = "ctrl/komfortDeviation";
+constexpr char CTRL_AUX_HEAT[]      = "ctrl/auxHeatMode";
+constexpr char CTRL_PV_TARGET[]     = "ctrl/pvTargetSetpoint";
+constexpr char CTRL_ANTI_LEGIO_INT[]= "ctrl/antiLegionellaInterval";
+constexpr char CTRL_FROST_PROT[]    = "ctrl/frostProtectTemp";
+constexpr char CTRL_EXT_PRIORITY[]  = "ctrl/extSourcePriority";
+constexpr char CTRL_BIVALENT[]      = "ctrl/bivalentThreshold";
+constexpr char CTRL_EXT_MAX_TEMP[]  = "ctrl/extSourceMaxTemp";
 
 // Program enum strings
 constexpr char ENUM_PROGRAM_NORMAL[]       = "NORMAL";
@@ -86,6 +96,10 @@ constexpr char ENUM_STATE_UNKNOWN[]  = "UNKNOWN";
 constexpr char ENUM_AUX_ELECTRIC[] = "ELECTRIC";
 constexpr char ENUM_AUX_EXTERNAL[] = "EXTERNAL";
 constexpr char ENUM_AUX_BOTH[]     = "BOTH";
+
+// Ext source priority enum strings
+constexpr char ENUM_PRIORITY_DEVICE[]   = "DEVICE";
+constexpr char ENUM_PRIORITY_EXTERNAL[] = "EXTERNAL";
 
 // Last will
 constexpr char LWT_TOPIC[]   = "aquamqtt/status";
@@ -201,14 +215,14 @@ void Optitronic2MQTTTask::loop()
 
 void Optitronic2MQTTTask::connectMqtt()
 {
-    mMQTTClient.begin(config::brokerAddr, config::brokerPort, mWiFiClient);
+    mMQTTClient.begin(mqttConfig.server.c_str(), mqttConfig.port, mWiFiClient);
     mMQTTClient.onMessage([](const String& topic, const String& payload) { mqttMessageCallback(topic, payload); });
     mMQTTClient.setWill(o2mqtt::LWT_TOPIC, o2mqtt::LWT_OFFLINE, true, 1);
 
     if (mMQTTClient.connect(
-                config::brokerClientId,
-                strlen(config::brokerUser) == 0 ? nullptr : config::brokerUser,
-                strlen(config::brokerPassword) == 0 ? nullptr : config::brokerPassword))
+                mqttConfig.clientId.c_str(),
+                mqttConfig.user.length() == 0 ? nullptr : mqttConfig.user.c_str(),
+                mqttConfig.password.length() == 0 ? nullptr : mqttConfig.password.c_str()))
     {
         Serial.println("[o2mqtt] connected to broker");
 
@@ -380,7 +394,7 @@ void Optitronic2MQTTTask::publishStats()
 
 void Optitronic2MQTTTask::publishDiscovery()
 {
-    if (!config::ENABLE_HOMEASSISTANT_DISCOVERY_MODE)
+    if (!mqttConfig.enableDiscovery)
     {
         return;
     }
@@ -400,14 +414,14 @@ void Optitronic2MQTTTask::publishDiscovery()
 
         auto device        = doc["dev"].to<JsonObject>();
         device["ids"]      = "aquamqtt_optitronic2";
-        device["name"]     = config::heatpumpModelName;
+        device["name"]     = aquaMqttConfig.heatpumpModelName.c_str();
         device["mf"]       = "Austria Email";
         device["mdl"]      = "WPA 450 ECO (Optitronic 2)";
         device["sw"]       = String("AquaMQTT ") + aquamqtt::VERSION;
 
         char discoveryTopic[128];
         snprintf(discoveryTopic, sizeof(discoveryTopic), "%ssensor/aquamqtt_o2/%s/config",
-                 config::haDiscoveryPrefix, uniqueIdSuffix);
+                 mqttConfig.discoveryPrefix.c_str(), uniqueIdSuffix);
 
         char payload[512];
         serializeJson(doc, payload, sizeof(payload));
@@ -429,14 +443,14 @@ void Optitronic2MQTTTask::publishDiscovery()
 
         auto device        = doc["dev"].to<JsonObject>();
         device["ids"]      = "aquamqtt_optitronic2";
-        device["name"]     = config::heatpumpModelName;
+        device["name"]     = aquaMqttConfig.heatpumpModelName.c_str();
         device["mf"]       = "Austria Email";
         device["mdl"]      = "WPA 450 ECO (Optitronic 2)";
         device["sw"]       = String("AquaMQTT ") + aquamqtt::VERSION;
 
         char discoveryTopic[128];
         snprintf(discoveryTopic, sizeof(discoveryTopic), "%snumber/aquamqtt_o2/%s/config",
-                 config::haDiscoveryPrefix, uniqueIdSuffix);
+                 mqttConfig.discoveryPrefix.c_str(), uniqueIdSuffix);
 
         char payload[512];
         serializeJson(doc, payload, sizeof(payload));
@@ -459,14 +473,14 @@ void Optitronic2MQTTTask::publishDiscovery()
 
         auto device        = doc["dev"].to<JsonObject>();
         device["ids"]      = "aquamqtt_optitronic2";
-        device["name"]     = config::heatpumpModelName;
+        device["name"]     = aquaMqttConfig.heatpumpModelName.c_str();
         device["mf"]       = "Austria Email";
         device["mdl"]      = "WPA 450 ECO (Optitronic 2)";
         device["sw"]       = String("AquaMQTT ") + aquamqtt::VERSION;
 
         char discoveryTopic[128];
         snprintf(discoveryTopic, sizeof(discoveryTopic), "%sselect/aquamqtt_o2/%s/config",
-                 config::haDiscoveryPrefix, uniqueIdSuffix);
+                 mqttConfig.discoveryPrefix.c_str(), uniqueIdSuffix);
 
         char payload[512];
         serializeJson(doc, payload, sizeof(payload));
@@ -485,14 +499,14 @@ void Optitronic2MQTTTask::publishDiscovery()
 
         auto device        = doc["dev"].to<JsonObject>();
         device["ids"]      = "aquamqtt_optitronic2";
-        device["name"]     = config::heatpumpModelName;
+        device["name"]     = aquaMqttConfig.heatpumpModelName.c_str();
         device["mf"]       = "Austria Email";
         device["mdl"]      = "WPA 450 ECO (Optitronic 2)";
         device["sw"]       = String("AquaMQTT ") + aquamqtt::VERSION;
 
         char discoveryTopic[128];
         snprintf(discoveryTopic, sizeof(discoveryTopic), "%sswitch/aquamqtt_o2/%s/config",
-                 config::haDiscoveryPrefix, uniqueIdSuffix);
+                 mqttConfig.discoveryPrefix.c_str(), uniqueIdSuffix);
 
         char payload[512];
         serializeJson(doc, payload, sizeof(payload));
@@ -605,86 +619,102 @@ void Optitronic2MQTTTask::handleMessage(const String& topic, const String& paylo
             ESP.restart();
         }
     }
+    else if (topic.endsWith("ecoDeviation"))
+    {
+        float dev = payload.toFloat();
+        if (dev >= -15.0f && dev <= 0.0f)
+        {
+            queueWrite(REG_ECO_DEVIATION, tempToReg(dev));
+        }
+    }
+    else if (topic.endsWith("komfortDeviation"))
+    {
+        float dev = payload.toFloat();
+        if (dev >= 0.0f && dev <= 10.0f)
+        {
+            queueWrite(REG_KOMFORT_DEVIATION, tempToReg(dev));
+        }
+    }
+    else if (topic.endsWith("auxHeatMode"))
+    {
+        if (payload == o2mqtt::ENUM_AUX_ELECTRIC)
+            queueWrite(REG_AUX_HEAT_MODE, AUX_HEAT_ELECTRIC);
+        else if (payload == o2mqtt::ENUM_AUX_EXTERNAL)
+            queueWrite(REG_AUX_HEAT_MODE, AUX_HEAT_EXTERNAL);
+        else if (payload == o2mqtt::ENUM_AUX_BOTH)
+            queueWrite(REG_AUX_HEAT_MODE, AUX_HEAT_BOTH);
+    }
+    else if (topic.endsWith("pvTargetSetpoint"))
+    {
+        float temp = payload.toFloat();
+        if (temp >= 35.0f && temp <= 70.0f)
+        {
+            queueWrite(REG_PV_TARGET_SETPOINT, tempToReg(temp));
+        }
+    }
+    else if (topic.endsWith("antiLegionellaInterval"))
+    {
+        int days = payload.toInt();
+        if (days >= 0 && days <= 30)
+        {
+            queueWrite(REG_ANTI_LEGIO_INTERVAL, (uint16_t)days);
+        }
+    }
+    else if (topic.endsWith("frostProtectTemp"))
+    {
+        float temp = payload.toFloat();
+        if (temp >= 2.0f && temp <= 15.0f)
+        {
+            queueWrite(REG_FROST_PROTECT_TEMP, tempToReg(temp));
+        }
+    }
+    else if (topic.endsWith("extSourcePriority"))
+    {
+        if (payload == o2mqtt::ENUM_PRIORITY_DEVICE)
+            queueWrite(REG_EXT_SOURCE_PRIORITY, 0);
+        else if (payload == o2mqtt::ENUM_PRIORITY_EXTERNAL)
+            queueWrite(REG_EXT_SOURCE_PRIORITY, 1);
+    }
+    else if (topic.endsWith("bivalentThreshold"))
+    {
+        float temp = payload.toFloat();
+        if (temp >= -10.0f && temp <= 20.0f)
+        {
+            queueWrite(REG_BIVALENT_THRESHOLD, tempToReg(temp));
+        }
+    }
+    else if (topic.endsWith("extSourceMaxTemp"))
+    {
+        float temp = payload.toFloat();
+        if (temp >= 35.0f && temp <= 70.0f)
+        {
+            queueWrite(REG_EXT_SOURCE_MAX_TEMP, tempToReg(temp));
+        }
+    }
 }
 
 void Optitronic2MQTTTask::handleSetDhwSetpoint(float temp)
 {
-    uint16_t reg   = REG_DHW_SETPOINT;
-    uint16_t value = tempToReg(temp);
-
-    if (xSemaphoreTake(mWriteMutex, pdMS_TO_TICKS(100)))
-    {
-        for (auto& cmd : mWriteQueue)
-        {
-            if (!cmd.pending)
-            {
-                cmd.reg     = reg;
-                cmd.value   = value;
-                cmd.pending = true;
-                break;
-            }
-        }
-        xSemaphoreGive(mWriteMutex);
-    }
+    queueWrite(REG_DHW_SETPOINT, tempToReg(temp));
 }
 
 void Optitronic2MQTTTask::handleSetProgram(uint16_t program)
 {
-    if (xSemaphoreTake(mWriteMutex, pdMS_TO_TICKS(100)))
-    {
-        for (auto& cmd : mWriteQueue)
-        {
-            if (!cmd.pending)
-            {
-                cmd.reg     = REG_PROGRAM;
-                cmd.value   = program;
-                cmd.pending = true;
-                break;
-            }
-        }
-        xSemaphoreGive(mWriteMutex);
-    }
+    queueWrite(REG_PROGRAM, program);
 }
 
 void Optitronic2MQTTTask::handleSetExtInputFunction(uint16_t fn)
 {
-    if (xSemaphoreTake(mWriteMutex, pdMS_TO_TICKS(100)))
-    {
-        for (auto& cmd : mWriteQueue)
-        {
-            if (!cmd.pending)
-            {
-                cmd.reg     = REG_EXT_INPUT_FUNCTION;
-                cmd.value   = fn;
-                cmd.pending = true;
-                break;
-            }
-        }
-        xSemaphoreGive(mWriteMutex);
-    }
+    queueWrite(REG_EXT_INPUT_FUNCTION, fn);
 }
 
 void Optitronic2MQTTTask::handleSetForceHeating(bool enable)
 {
-    if (xSemaphoreTake(mWriteMutex, pdMS_TO_TICKS(100)))
-    {
-        for (auto& cmd : mWriteQueue)
-        {
-            if (!cmd.pending)
-            {
-                cmd.reg     = REG_FORCE_HEATING;
-                cmd.value   = enable ? 1 : 0;
-                cmd.pending = true;
-                break;
-            }
-        }
-        xSemaphoreGive(mWriteMutex);
-    }
+    queueWrite(REG_FORCE_HEATING, enable ? 1 : 0);
 }
 
 void Optitronic2MQTTTask::handleSetQuickHeat(bool activate, float target)
 {
-    // Get current quick heat register value for the target
     uint16_t currentReg = 0;
     Optitronic2State::getInstance().getRegister(REG_QUICK_HEAT_STATE, currentReg);
     uint16_t currentTarget = getQuickHeatTarget(currentReg);
@@ -697,26 +727,18 @@ void Optitronic2MQTTTask::handleSetQuickHeat(bool activate, float target)
     }
     else
     {
-        value = currentTarget;  // just the target without bit15
+        value = currentTarget;
     }
 
-    if (xSemaphoreTake(mWriteMutex, pdMS_TO_TICKS(100)))
-    {
-        for (auto& cmd : mWriteQueue)
-        {
-            if (!cmd.pending)
-            {
-                cmd.reg     = REG_QUICK_HEAT_STATE;
-                cmd.value   = value;
-                cmd.pending = true;
-                break;
-            }
-        }
-        xSemaphoreGive(mWriteMutex);
-    }
+    queueWrite(REG_QUICK_HEAT_STATE, value);
 }
 
 void Optitronic2MQTTTask::handleTriggerAntiLegionella()
+{
+    queueWrite(REG_ANTI_LEGIONELLA, 1);
+}
+
+void Optitronic2MQTTTask::queueWrite(uint16_t reg, uint16_t value)
 {
     if (xSemaphoreTake(mWriteMutex, pdMS_TO_TICKS(100)))
     {
@@ -724,8 +746,8 @@ void Optitronic2MQTTTask::handleTriggerAntiLegionella()
         {
             if (!cmd.pending)
             {
-                cmd.reg     = REG_ANTI_LEGIONELLA;
-                cmd.value   = 1;
+                cmd.reg     = reg;
+                cmd.value   = value;
                 cmd.pending = true;
                 break;
             }

--- a/AquaMQTT/src/task/Optitronic2MQTTTask.cpp
+++ b/AquaMQTT/src/task/Optitronic2MQTTTask.cpp
@@ -90,10 +90,16 @@ constexpr char ENUM_EXT_RESERVE[]      = "RESERVE";
 constexpr char ENUM_EXT_FUNCTION1[]    = "FUNCTION1";
 
 // Operating state enum strings
-constexpr char ENUM_STATE_IDLE[]     = "IDLE";
-constexpr char ENUM_STATE_HEATING[]  = "HEATING";
-constexpr char ENUM_STATE_PV_BOOST[] = "PV_BOOST";
-constexpr char ENUM_STATE_UNKNOWN[]  = "UNKNOWN";
+constexpr char ENUM_STATE_OFF[]              = "OFF";
+constexpr char ENUM_STATE_STANDBY[]          = "STANDBY";
+constexpr char ENUM_STATE_IDLE[]             = "IDLE";
+constexpr char ENUM_STATE_HEATING[]          = "HEATING";
+constexpr char ENUM_STATE_HEATING_ELECTRIC[] = "HEATING_ELECTRIC";
+constexpr char ENUM_STATE_HEATING_BOTH[]     = "HEATING_BOTH";
+constexpr char ENUM_STATE_PV_BOOST[]         = "PV_BOOST";
+constexpr char ENUM_STATE_DEFROST[]          = "DEFROST";
+constexpr char ENUM_STATE_ANTI_LEGIONELLA[]  = "ANTI_LEGIONELLA";
+constexpr char ENUM_STATE_UNKNOWN[]          = "UNKNOWN";
 
 // Aux heat mode enum strings
 constexpr char ENUM_AUX_ELECTRIC[] = "ELECTRIC";
@@ -358,20 +364,40 @@ void Optitronic2MQTTTask::publishState()
 
     publishFloat(o2mqtt::ACTIVE_SETPOINT, state.getActiveSetpoint());
 
+    uint16_t rawState = state.getOperatingState();
     const char* stateStr = o2mqtt::ENUM_STATE_UNKNOWN;
-    switch (state.getOperatingState())
+    switch (rawState)
     {
+        case STATE_OFF:
+            stateStr = o2mqtt::ENUM_STATE_OFF;
+            break;
+        case STATE_STANDBY:
+            stateStr = o2mqtt::ENUM_STATE_STANDBY;
+            break;
         case STATE_IDLE:
             stateStr = o2mqtt::ENUM_STATE_IDLE;
             break;
         case STATE_HEATING:
             stateStr = o2mqtt::ENUM_STATE_HEATING;
             break;
+        case STATE_HEATING_ELECTRIC:
+            stateStr = o2mqtt::ENUM_STATE_HEATING_ELECTRIC;
+            break;
+        case STATE_HEATING_BOTH:
+            stateStr = o2mqtt::ENUM_STATE_HEATING_BOTH;
+            break;
         case STATE_PV_BOOST:
             stateStr = o2mqtt::ENUM_STATE_PV_BOOST;
             break;
+        case STATE_DEFROST:
+            stateStr = o2mqtt::ENUM_STATE_DEFROST;
+            break;
+        case STATE_ANTI_LEGIONELLA:
+            stateStr = o2mqtt::ENUM_STATE_ANTI_LEGIONELLA;
+            break;
     }
     publishString(o2mqtt::OPERATING_STATE, stateStr);
+    publishInt("operatingStateRaw", rawState);
     publishBool(o2mqtt::QUICK_HEAT_ACTIVE, state.isQuickHeatActive());
 
     // Heat source active

--- a/AquaMQTT/src/task/Optitronic2MQTTTask.cpp
+++ b/AquaMQTT/src/task/Optitronic2MQTTTask.cpp
@@ -402,6 +402,8 @@ void Optitronic2MQTTTask::publishInstaller()
     {
         publishFloat(o2mqtt::FROST_PROTECT, state.getFrostProtectTemp());
         publishInt(o2mqtt::ANTI_LEGIO_DAYS, state.getAntiLegioInterval());
+        publishString("extSourcePriority",
+                      state.getExtSourcePriority() == 0 ? o2mqtt::ENUM_PRIORITY_DEVICE : o2mqtt::ENUM_PRIORITY_EXTERNAL);
     }
 
     if (state.hasBlock(REG_INSTALLER_BLK2_START))
@@ -588,12 +590,43 @@ void Optitronic2MQTTTask::publishDiscovery()
     publishSensorDiscovery("Evaporator Temperature", o2mqtt::EVAPORATOR_TEMP, "°C", "temperature", "evap_temp");
     publishSensorDiscovery("Active Setpoint", o2mqtt::ACTIVE_SETPOINT, "°C", "temperature", "active_setpoint");
     publishSensorDiscovery("Operating State", o2mqtt::OPERATING_STATE, nullptr, nullptr, "op_state");
+    publishSensorDiscovery("Heat Source", o2mqtt::HEAT_SOURCE, nullptr, nullptr, "heat_source");
+    publishSensorDiscovery("Heating Trigger", o2mqtt::COMPRESSOR_STATUS, nullptr, nullptr, "heat_trigger");
     publishSensorDiscovery("PV Active", o2mqtt::PV_ACTIVE, nullptr, nullptr, "pv_active");
     publishSensorDiscovery("Quick Heat Active", o2mqtt::QUICK_HEAT_ACTIVE, nullptr, nullptr, "quick_heat");
+    publishSensorDiscovery("Eco Deviation", o2mqtt::ECO_DEVIATION, "°C", "temperature", "eco_dev");
+    publishSensorDiscovery("Komfort Deviation", o2mqtt::KOMFORT_DEVIATION, "°C", "temperature", "komf_dev");
+    publishSensorDiscovery("Aux Heat Mode", o2mqtt::AUX_HEAT_MODE, nullptr, nullptr, "aux_heat_mode");
+    publishSensorDiscovery("Frost Protection Temp", o2mqtt::FROST_PROTECT, "°C", "temperature", "frost_protect");
+    publishSensorDiscovery("Anti-Legionella Interval", o2mqtt::ANTI_LEGIO_DAYS, "d", nullptr, "anti_legio_interval");
+    publishSensorDiscovery("Bivalent Threshold", o2mqtt::BIVALENT_THRESHOLD, "°C", "temperature", "bivalent_threshold");
+    publishSensorDiscovery("PV Target Setpoint", o2mqtt::PV_TARGET, "°C", "temperature", "pv_target");
+    publishSensorDiscovery("Ext Source Max Temp", o2mqtt::EXT_MAX_TEMP, "°C", "temperature", "ext_max_temp");
 
     // --- Controllable entities ---
     publishNumberDiscovery("DHW Target Temperature", o2mqtt::DHW_SETPOINT, o2mqtt::CTRL_SET_TEMP,
                            35.0, 70.0, 0.5, "°C", "dhw_setpoint");
+
+    publishNumberDiscovery("Eco Deviation", o2mqtt::ECO_DEVIATION, o2mqtt::CTRL_ECO_DEV,
+                           -15.0, 0.0, 0.5, "°C", "ctrl_eco_dev");
+
+    publishNumberDiscovery("Komfort Deviation", o2mqtt::KOMFORT_DEVIATION, o2mqtt::CTRL_KOMF_DEV,
+                           0.0, 10.0, 0.5, "°C", "ctrl_komf_dev");
+
+    publishNumberDiscovery("Frost Protection Temp", o2mqtt::FROST_PROTECT, o2mqtt::CTRL_FROST_PROT,
+                           2.0, 15.0, 0.5, "°C", "ctrl_frost_protect");
+
+    publishNumberDiscovery("Anti-Legionella Interval", o2mqtt::ANTI_LEGIO_DAYS, o2mqtt::CTRL_ANTI_LEGIO_INT,
+                           0.0, 30.0, 1.0, "d", "ctrl_anti_legio");
+
+    publishNumberDiscovery("PV Target Setpoint", o2mqtt::PV_TARGET, o2mqtt::CTRL_PV_TARGET,
+                           35.0, 70.0, 0.5, "°C", "ctrl_pv_target");
+
+    publishNumberDiscovery("Bivalent Threshold", o2mqtt::BIVALENT_THRESHOLD, o2mqtt::CTRL_BIVALENT,
+                           -10.0, 20.0, 0.5, "°C", "ctrl_bivalent");
+
+    publishNumberDiscovery("Ext Source Max Temp", o2mqtt::EXT_MAX_TEMP, o2mqtt::CTRL_EXT_MAX_TEMP,
+                           35.0, 70.0, 0.5, "°C", "ctrl_ext_max");
 
     const char* programOptions[] = { o2mqtt::ENUM_PROGRAM_NORMAL, o2mqtt::ENUM_PROGRAM_ECO,
                                      o2mqtt::ENUM_PROGRAM_KOMFORT, o2mqtt::ENUM_PROGRAM_KOMFORT_PLUS };
@@ -607,6 +640,14 @@ void Optitronic2MQTTTask::publishDiscovery()
                                       o2mqtt::ENUM_EXT_FUNCTION1 };
     publishSelectDiscovery("External Input Function", o2mqtt::EXT_INPUT_FN, o2mqtt::CTRL_SET_EXT_INPUT,
                            extInputOptions, 9, "ext_input");
+
+    const char* auxHeatOptions[] = { o2mqtt::ENUM_AUX_ELECTRIC, o2mqtt::ENUM_AUX_EXTERNAL, o2mqtt::ENUM_AUX_BOTH };
+    publishSelectDiscovery("Aux Heat Mode", o2mqtt::AUX_HEAT_MODE, o2mqtt::CTRL_AUX_HEAT,
+                           auxHeatOptions, 3, "aux_heat");
+
+    const char* priorityOptions[] = { o2mqtt::ENUM_PRIORITY_DEVICE, o2mqtt::ENUM_PRIORITY_EXTERNAL };
+    publishSelectDiscovery("Ext Source Priority", "extSourcePriority", o2mqtt::CTRL_EXT_PRIORITY,
+                           priorityOptions, 2, "ext_priority");
 
     publishSwitchDiscovery("Force Heating", o2mqtt::FORCE_HEATING, o2mqtt::CTRL_FORCE_HEAT, "force_heating");
 

--- a/AquaMQTT/src/task/Optitronic2MQTTTask.cpp
+++ b/AquaMQTT/src/task/Optitronic2MQTTTask.cpp
@@ -1,0 +1,803 @@
+#include "task/Optitronic2MQTTTask.h"
+
+#include <ArduinoJson.h>
+#include <WiFi.h>
+#include <esp_task_wdt.h>
+
+#include "Version.h"
+#include "config/Configuration.h"
+#include "message/optitronic2/RegisterMap.h"
+#include "state/Optitronic2State.h"
+
+using namespace aquamqtt::message::optitronic2;
+
+namespace aquamqtt
+{
+
+// MQTT topic definitions for Optitronic 2
+namespace o2mqtt
+{
+constexpr char BASE[]    = "aquamqtt/";
+constexpr char CTRL[]    = "aquamqtt/ctrl/";
+
+// Sensor topics (read-only)
+constexpr char WATER_TEMP[]         = "waterTemp";
+constexpr char AMBIENT_TEMP[]       = "supplyAirTemp";
+constexpr char EVAPORATOR_TEMP[]    = "evaporatorTemp";
+constexpr char PV_ACTIVE[]          = "statePV";
+constexpr char ACTIVE_SETPOINT[]    = "activeSetpoint";
+constexpr char OPERATING_STATE[]    = "operatingState";
+constexpr char QUICK_HEAT_ACTIVE[]  = "quickHeatActive";
+
+// Settings topics (read + writable)
+constexpr char DHW_SETPOINT[]       = "waterTempTarget";
+constexpr char PROGRAM[]            = "operationMode";
+constexpr char AUX_HEAT_MODE[]      = "auxHeatMode";
+constexpr char EXT_INPUT_FN[]       = "extInputFunction";
+constexpr char ECO_DEVIATION[]      = "ecoDeviation";
+constexpr char KOMFORT_DEVIATION[]  = "komfortDeviation";
+constexpr char FORCE_HEATING[]      = "forceHeating";
+
+// Installer topics (read-only, available after installer menu access)
+constexpr char FROST_PROTECT[]      = "frostProtectTemp";
+constexpr char BIVALENT_THRESHOLD[] = "bivalentThreshold";
+constexpr char PV_TARGET[]          = "pvTargetSetpoint";
+constexpr char EXT_MAX_TEMP[]       = "extSourceMaxTemp";
+constexpr char ANTI_LEGIO_DAYS[]    = "antiLegionellaInterval";
+
+// Stats
+constexpr char STATS_FRAMES[]       = "stats/framesReceived";
+constexpr char STATS_CRC_ERR[]      = "stats/crcErrors";
+constexpr char STATS_REG_UPDATES[]  = "stats/registerUpdates";
+constexpr char STATS_LAST_UPDATE[]  = "stats/lastUpdateMs";
+
+// Control subtopics (for subscribing)
+constexpr char CTRL_SET_TEMP[]      = "ctrl/waterTempTarget";
+constexpr char CTRL_SET_PROGRAM[]   = "ctrl/operationMode";
+constexpr char CTRL_SET_EXT_INPUT[] = "ctrl/extInputFunction";
+constexpr char CTRL_FORCE_HEAT[]    = "ctrl/forceHeating";
+constexpr char CTRL_QUICK_HEAT[]    = "ctrl/quickHeat";
+constexpr char CTRL_ANTI_LEGIO[]    = "ctrl/triggerAntiLegionella";
+constexpr char CTRL_RESET[]         = "ctrl/reset";
+
+// Program enum strings
+constexpr char ENUM_PROGRAM_NORMAL[]       = "NORMAL";
+constexpr char ENUM_PROGRAM_ECO[]          = "ECO";
+constexpr char ENUM_PROGRAM_KOMFORT[]      = "KOMFORT";
+constexpr char ENUM_PROGRAM_KOMFORT_PLUS[] = "KOMFORT_PLUS";
+
+// Ext input enum strings
+constexpr char ENUM_EXT_QUICK_HEAT[]   = "QUICK_HEAT";
+constexpr char ENUM_EXT_OFF[]          = "OFF";
+constexpr char ENUM_EXT_NORMAL[]       = "NORMAL";
+constexpr char ENUM_EXT_ECO[]          = "ECO";
+constexpr char ENUM_EXT_KOMFORT[]      = "KOMFORT";
+constexpr char ENUM_EXT_KOMFORT_PLUS[] = "KOMFORT_PLUS";
+constexpr char ENUM_EXT_PV[]           = "PHOTOVOLTAIK";
+constexpr char ENUM_EXT_RESERVE[]      = "RESERVE";
+constexpr char ENUM_EXT_FUNCTION1[]    = "FUNCTION1";
+
+// Operating state enum strings
+constexpr char ENUM_STATE_IDLE[]     = "IDLE";
+constexpr char ENUM_STATE_PV_BOOST[] = "PV_BOOST";
+constexpr char ENUM_STATE_UNKNOWN[]  = "UNKNOWN";
+
+// Aux heat mode enum strings
+constexpr char ENUM_AUX_ELECTRIC[] = "ELECTRIC";
+constexpr char ENUM_AUX_EXTERNAL[] = "EXTERNAL";
+constexpr char ENUM_AUX_BOTH[]     = "BOTH";
+
+// Last will
+constexpr char LWT_TOPIC[]   = "aquamqtt/status";
+constexpr char LWT_ONLINE[]  = "ONLINE";
+constexpr char LWT_OFFLINE[] = "OFFLINE";
+}  // namespace o2mqtt
+
+// Static callback trampoline
+static Optitronic2MQTTTask* sInstance = nullptr;
+
+static void mqttMessageCallback(const String& topic, const String& payload)
+{
+    if (sInstance != nullptr)
+    {
+        sInstance->handleMessage(topic, payload);
+    }
+}
+
+Optitronic2MQTTTask::Optitronic2MQTTTask()
+    : mMQTTClient(512)
+    , mTaskHandle(nullptr)
+    , mTopicBuffer{}
+    , mPayloadBuffer{}
+    , mLastFullUpdate(0)
+    , mLastStatsUpdate(0)
+    , mPublishedDiscovery(false)
+    , mWriteQueue{}
+    , mWriteQueueHead(0)
+    , mWriteMutex(xSemaphoreCreateMutex())
+{
+    sInstance = this;
+}
+
+void Optitronic2MQTTTask::spawn()
+{
+    xTaskCreatePinnedToCore(Optitronic2MQTTTask::innerTask, "o2mqttLoop", 8192, this, 3, &mTaskHandle, 0);
+    esp_task_wdt_add(mTaskHandle);
+
+    // Register ourselves with state for change notifications
+    Optitronic2State::getInstance().setListener(mTaskHandle);
+}
+
+[[noreturn]] void Optitronic2MQTTTask::innerTask(void* pvParameters)
+{
+    auto* self = static_cast<Optitronic2MQTTTask*>(pvParameters);
+    self->setup();
+
+    while (true)
+    {
+        esp_task_wdt_reset();
+        self->loop();
+    }
+}
+
+void Optitronic2MQTTTask::setup()
+{
+    // nothing additional needed — MQTT connection handled in loop
+}
+
+void Optitronic2MQTTTask::loop()
+{
+    unsigned long now = millis();
+
+    if (!mMQTTClient.connected())
+    {
+        connectMqtt();
+        vTaskDelay(pdMS_TO_TICKS(1000));
+        return;
+    }
+
+    mMQTTClient.loop();
+
+    // Wait for notification from state changes or periodic timeout
+    uint32_t notifyValue = 0;
+    xTaskNotifyWaitIndexed(0, 0, 0xFFFFFFFF, &notifyValue, pdMS_TO_TICKS(5000));
+
+    // Publish HA discovery once after first data arrives
+    if (!mPublishedDiscovery && Optitronic2State::getInstance().hasBlock(REG_BLOCK1_START))
+    {
+        publishDiscovery();
+        mPublishedDiscovery = true;
+    }
+
+    // Publish based on what changed
+    if (notifyValue & Optitronic2State::CHANGE_SENSORS)
+    {
+        publishSensors();
+    }
+    if (notifyValue & (Optitronic2State::CHANGE_SETTINGS | Optitronic2State::CHANGE_STATE))
+    {
+        publishSettings();
+        publishState();
+    }
+    if (notifyValue & Optitronic2State::CHANGE_INSTALLER)
+    {
+        publishInstaller();
+    }
+
+    // Full update every 60s regardless of changes
+    if ((now - mLastFullUpdate) >= 60000)
+    {
+        publishAll();
+        mLastFullUpdate = now;
+    }
+
+    // Stats every 10s
+    if ((now - mLastStatsUpdate) >= 10000)
+    {
+        publishStats();
+        mLastStatsUpdate = now;
+    }
+}
+
+void Optitronic2MQTTTask::connectMqtt()
+{
+    mMQTTClient.begin(config::brokerAddr, config::brokerPort, mWiFiClient);
+    mMQTTClient.onMessage([](const String& topic, const String& payload) { mqttMessageCallback(topic, payload); });
+    mMQTTClient.setWill(o2mqtt::LWT_TOPIC, o2mqtt::LWT_OFFLINE, true, 1);
+
+    if (mMQTTClient.connect(
+                config::brokerClientId,
+                strlen(config::brokerUser) == 0 ? nullptr : config::brokerUser,
+                strlen(config::brokerPassword) == 0 ? nullptr : config::brokerPassword))
+    {
+        Serial.println("[o2mqtt] connected to broker");
+
+        // Subscribe to control topics
+        mMQTTClient.subscribe("aquamqtt/ctrl/#");
+
+        // Publish online status
+        mMQTTClient.publish(o2mqtt::LWT_TOPIC, o2mqtt::LWT_ONLINE, true, 1);
+    }
+}
+
+void Optitronic2MQTTTask::publishAll()
+{
+    publishSensors();
+    publishSettings();
+    publishState();
+    publishInstaller();
+}
+
+void Optitronic2MQTTTask::publishSensors()
+{
+    auto& state = Optitronic2State::getInstance();
+
+    if (state.hasBlock(REG_BLOCK2_START))
+    {
+        publishFloat(o2mqtt::WATER_TEMP, state.getWaterTemp());
+        publishFloat(o2mqtt::AMBIENT_TEMP, state.getAmbientTemp());
+        publishFloat(o2mqtt::EVAPORATOR_TEMP, state.getEvaporatorTemp());
+        publishBool(o2mqtt::PV_ACTIVE, state.isPvActive());
+    }
+}
+
+void Optitronic2MQTTTask::publishSettings()
+{
+    auto& state = Optitronic2State::getInstance();
+
+    if (!state.hasBlock(REG_BLOCK1_START))
+    {
+        return;
+    }
+
+    publishFloat(o2mqtt::DHW_SETPOINT, state.getDhwSetpoint());
+    publishFloat(o2mqtt::ECO_DEVIATION, state.getEcoDeviation());
+    publishFloat(o2mqtt::KOMFORT_DEVIATION, state.getKomfortDeviation());
+
+    // Program enum
+    const char* programStr = o2mqtt::ENUM_STATE_UNKNOWN;
+    switch (state.getProgram())
+    {
+        case PROGRAM_NORMAL:
+            programStr = o2mqtt::ENUM_PROGRAM_NORMAL;
+            break;
+        case PROGRAM_ECO:
+            programStr = o2mqtt::ENUM_PROGRAM_ECO;
+            break;
+        case PROGRAM_KOMFORT:
+            programStr = o2mqtt::ENUM_PROGRAM_KOMFORT;
+            break;
+        case PROGRAM_KOMFORT_PLUS:
+            programStr = o2mqtt::ENUM_PROGRAM_KOMFORT_PLUS;
+            break;
+    }
+    publishString(o2mqtt::PROGRAM, programStr);
+
+    // Aux heat mode
+    const char* auxStr = o2mqtt::ENUM_STATE_UNKNOWN;
+    switch (state.getAuxHeatMode())
+    {
+        case AUX_HEAT_ELECTRIC:
+            auxStr = o2mqtt::ENUM_AUX_ELECTRIC;
+            break;
+        case AUX_HEAT_EXTERNAL:
+            auxStr = o2mqtt::ENUM_AUX_EXTERNAL;
+            break;
+        case AUX_HEAT_BOTH:
+            auxStr = o2mqtt::ENUM_AUX_BOTH;
+            break;
+    }
+    publishString(o2mqtt::AUX_HEAT_MODE, auxStr);
+
+    // Ext input function
+    const char* extStr = o2mqtt::ENUM_STATE_UNKNOWN;
+    switch (state.getExtInputFunction())
+    {
+        case EXT_INPUT_QUICK_HEAT:
+            extStr = o2mqtt::ENUM_EXT_QUICK_HEAT;
+            break;
+        case EXT_INPUT_OFF:
+            extStr = o2mqtt::ENUM_EXT_OFF;
+            break;
+        case EXT_INPUT_NORMAL:
+            extStr = o2mqtt::ENUM_EXT_NORMAL;
+            break;
+        case EXT_INPUT_ECO:
+            extStr = o2mqtt::ENUM_EXT_ECO;
+            break;
+        case EXT_INPUT_KOMFORT:
+            extStr = o2mqtt::ENUM_EXT_KOMFORT;
+            break;
+        case EXT_INPUT_KOMFORT_PLUS:
+            extStr = o2mqtt::ENUM_EXT_KOMFORT_PLUS;
+            break;
+        case EXT_INPUT_PHOTOVOLTAIK:
+            extStr = o2mqtt::ENUM_EXT_PV;
+            break;
+        case EXT_INPUT_RESERVE:
+            extStr = o2mqtt::ENUM_EXT_RESERVE;
+            break;
+        case EXT_INPUT_FUNCTION_1:
+            extStr = o2mqtt::ENUM_EXT_FUNCTION1;
+            break;
+    }
+    publishString(o2mqtt::EXT_INPUT_FN, extStr);
+
+    publishBool(o2mqtt::FORCE_HEATING, state.isForceHeating());
+}
+
+void Optitronic2MQTTTask::publishState()
+{
+    auto& state = Optitronic2State::getInstance();
+
+    if (!state.hasBlock(REG_BLOCK1_START))
+    {
+        return;
+    }
+
+    publishFloat(o2mqtt::ACTIVE_SETPOINT, state.getActiveSetpoint());
+
+    const char* stateStr = o2mqtt::ENUM_STATE_UNKNOWN;
+    switch (state.getOperatingState())
+    {
+        case STATE_IDLE_HEATING:
+            stateStr = o2mqtt::ENUM_STATE_IDLE;
+            break;
+        case STATE_PV_BOOST:
+            stateStr = o2mqtt::ENUM_STATE_PV_BOOST;
+            break;
+    }
+    publishString(o2mqtt::OPERATING_STATE, stateStr);
+    publishBool(o2mqtt::QUICK_HEAT_ACTIVE, state.isQuickHeatActive());
+}
+
+void Optitronic2MQTTTask::publishInstaller()
+{
+    auto& state = Optitronic2State::getInstance();
+
+    if (state.hasBlock(REG_INSTALLER_BLK1_START))
+    {
+        publishFloat(o2mqtt::FROST_PROTECT, state.getFrostProtectTemp());
+        publishInt(o2mqtt::ANTI_LEGIO_DAYS, state.getAntiLegioInterval());
+    }
+
+    if (state.hasBlock(REG_INSTALLER_BLK2_START))
+    {
+        publishFloat(o2mqtt::BIVALENT_THRESHOLD, state.getBivalentThreshold());
+        publishFloat(o2mqtt::PV_TARGET, state.getPvTargetSetpoint());
+        publishFloat(o2mqtt::EXT_MAX_TEMP, state.getExtSourceMaxTemp());
+    }
+}
+
+void Optitronic2MQTTTask::publishStats()
+{
+    auto stats = Optitronic2State::getInstance().getStats();
+    publishInt(o2mqtt::STATS_FRAMES, stats.framesReceived);
+    publishInt(o2mqtt::STATS_CRC_ERR, stats.crcErrors);
+    publishInt(o2mqtt::STATS_REG_UPDATES, stats.registerUpdates);
+    publishInt(o2mqtt::STATS_LAST_UPDATE, stats.lastUpdateMs);
+}
+
+void Optitronic2MQTTTask::publishDiscovery()
+{
+    if (!config::ENABLE_HOMEASSISTANT_DISCOVERY_MODE)
+    {
+        return;
+    }
+
+    // Helper lambda to publish a HA discovery config
+    auto publishSensorDiscovery = [&](const char* name, const char* stateTopic, const char* unit,
+                                      const char* deviceClass, const char* uniqueIdSuffix) {
+        JsonDocument doc;
+        doc["name"]                = name;
+        doc["stat_t"]              = String(o2mqtt::BASE) + stateTopic;
+        doc["uniq_id"]             = String("aquamqtt_o2_") + uniqueIdSuffix;
+        doc["val_tpl"]             = "{{ value }}";
+        if (unit != nullptr)
+            doc["unit_of_meas"] = unit;
+        if (deviceClass != nullptr)
+            doc["dev_cla"] = deviceClass;
+
+        auto device        = doc["dev"].to<JsonObject>();
+        device["ids"]      = "aquamqtt_optitronic2";
+        device["name"]     = config::heatpumpModelName;
+        device["mf"]       = "Austria Email";
+        device["mdl"]      = "WPA 450 ECO (Optitronic 2)";
+        device["sw"]       = String("AquaMQTT ") + aquamqtt::VERSION;
+
+        char discoveryTopic[128];
+        snprintf(discoveryTopic, sizeof(discoveryTopic), "%ssensor/aquamqtt_o2/%s/config",
+                 config::haDiscoveryPrefix, uniqueIdSuffix);
+
+        char payload[512];
+        serializeJson(doc, payload, sizeof(payload));
+        mMQTTClient.publish(discoveryTopic, payload, true, 0);
+    };
+
+    auto publishNumberDiscovery = [&](const char* name, const char* stateTopic, const char* cmdTopic,
+                                      float min, float max, float step, const char* unit, const char* uniqueIdSuffix) {
+        JsonDocument doc;
+        doc["name"]       = name;
+        doc["stat_t"]     = String(o2mqtt::BASE) + stateTopic;
+        doc["cmd_t"]      = String(o2mqtt::BASE) + cmdTopic;
+        doc["uniq_id"]    = String("aquamqtt_o2_") + uniqueIdSuffix;
+        doc["min"]        = min;
+        doc["max"]        = max;
+        doc["step"]       = step;
+        if (unit != nullptr)
+            doc["unit_of_meas"] = unit;
+
+        auto device        = doc["dev"].to<JsonObject>();
+        device["ids"]      = "aquamqtt_optitronic2";
+        device["name"]     = config::heatpumpModelName;
+        device["mf"]       = "Austria Email";
+        device["mdl"]      = "WPA 450 ECO (Optitronic 2)";
+        device["sw"]       = String("AquaMQTT ") + aquamqtt::VERSION;
+
+        char discoveryTopic[128];
+        snprintf(discoveryTopic, sizeof(discoveryTopic), "%snumber/aquamqtt_o2/%s/config",
+                 config::haDiscoveryPrefix, uniqueIdSuffix);
+
+        char payload[512];
+        serializeJson(doc, payload, sizeof(payload));
+        mMQTTClient.publish(discoveryTopic, payload, true, 0);
+    };
+
+    auto publishSelectDiscovery = [&](const char* name, const char* stateTopic, const char* cmdTopic,
+                                      const char* const* options, uint8_t optionCount, const char* uniqueIdSuffix) {
+        JsonDocument doc;
+        doc["name"]       = name;
+        doc["stat_t"]     = String(o2mqtt::BASE) + stateTopic;
+        doc["cmd_t"]      = String(o2mqtt::BASE) + cmdTopic;
+        doc["uniq_id"]    = String("aquamqtt_o2_") + uniqueIdSuffix;
+
+        auto opts = doc["options"].to<JsonArray>();
+        for (uint8_t i = 0; i < optionCount; i++)
+        {
+            opts.add(options[i]);
+        }
+
+        auto device        = doc["dev"].to<JsonObject>();
+        device["ids"]      = "aquamqtt_optitronic2";
+        device["name"]     = config::heatpumpModelName;
+        device["mf"]       = "Austria Email";
+        device["mdl"]      = "WPA 450 ECO (Optitronic 2)";
+        device["sw"]       = String("AquaMQTT ") + aquamqtt::VERSION;
+
+        char discoveryTopic[128];
+        snprintf(discoveryTopic, sizeof(discoveryTopic), "%sselect/aquamqtt_o2/%s/config",
+                 config::haDiscoveryPrefix, uniqueIdSuffix);
+
+        char payload[512];
+        serializeJson(doc, payload, sizeof(payload));
+        mMQTTClient.publish(discoveryTopic, payload, true, 0);
+    };
+
+    auto publishSwitchDiscovery = [&](const char* name, const char* stateTopic, const char* cmdTopic,
+                                      const char* uniqueIdSuffix) {
+        JsonDocument doc;
+        doc["name"]       = name;
+        doc["stat_t"]     = String(o2mqtt::BASE) + stateTopic;
+        doc["cmd_t"]      = String(o2mqtt::BASE) + cmdTopic;
+        doc["uniq_id"]    = String("aquamqtt_o2_") + uniqueIdSuffix;
+        doc["pl_on"]      = "1";
+        doc["pl_off"]     = "0";
+
+        auto device        = doc["dev"].to<JsonObject>();
+        device["ids"]      = "aquamqtt_optitronic2";
+        device["name"]     = config::heatpumpModelName;
+        device["mf"]       = "Austria Email";
+        device["mdl"]      = "WPA 450 ECO (Optitronic 2)";
+        device["sw"]       = String("AquaMQTT ") + aquamqtt::VERSION;
+
+        char discoveryTopic[128];
+        snprintf(discoveryTopic, sizeof(discoveryTopic), "%sswitch/aquamqtt_o2/%s/config",
+                 config::haDiscoveryPrefix, uniqueIdSuffix);
+
+        char payload[512];
+        serializeJson(doc, payload, sizeof(payload));
+        mMQTTClient.publish(discoveryTopic, payload, true, 0);
+    };
+
+    // --- Sensors ---
+    publishSensorDiscovery("Water Temperature", o2mqtt::WATER_TEMP, "°C", "temperature", "water_temp");
+    publishSensorDiscovery("Ambient Temperature", o2mqtt::AMBIENT_TEMP, "°C", "temperature", "ambient_temp");
+    publishSensorDiscovery("Evaporator Temperature", o2mqtt::EVAPORATOR_TEMP, "°C", "temperature", "evap_temp");
+    publishSensorDiscovery("Active Setpoint", o2mqtt::ACTIVE_SETPOINT, "°C", "temperature", "active_setpoint");
+    publishSensorDiscovery("Operating State", o2mqtt::OPERATING_STATE, nullptr, nullptr, "op_state");
+    publishSensorDiscovery("PV Active", o2mqtt::PV_ACTIVE, nullptr, nullptr, "pv_active");
+    publishSensorDiscovery("Quick Heat Active", o2mqtt::QUICK_HEAT_ACTIVE, nullptr, nullptr, "quick_heat");
+
+    // --- Controllable entities ---
+    publishNumberDiscovery("DHW Target Temperature", o2mqtt::DHW_SETPOINT, o2mqtt::CTRL_SET_TEMP,
+                           35.0, 70.0, 0.5, "°C", "dhw_setpoint");
+
+    const char* programOptions[] = { o2mqtt::ENUM_PROGRAM_NORMAL, o2mqtt::ENUM_PROGRAM_ECO,
+                                     o2mqtt::ENUM_PROGRAM_KOMFORT, o2mqtt::ENUM_PROGRAM_KOMFORT_PLUS };
+    publishSelectDiscovery("Operating Program", o2mqtt::PROGRAM, o2mqtt::CTRL_SET_PROGRAM,
+                           programOptions, 4, "program");
+
+    const char* extInputOptions[] = { o2mqtt::ENUM_EXT_QUICK_HEAT, o2mqtt::ENUM_EXT_OFF,
+                                      o2mqtt::ENUM_EXT_NORMAL, o2mqtt::ENUM_EXT_ECO,
+                                      o2mqtt::ENUM_EXT_KOMFORT, o2mqtt::ENUM_EXT_KOMFORT_PLUS,
+                                      o2mqtt::ENUM_EXT_PV, o2mqtt::ENUM_EXT_RESERVE,
+                                      o2mqtt::ENUM_EXT_FUNCTION1 };
+    publishSelectDiscovery("External Input Function", o2mqtt::EXT_INPUT_FN, o2mqtt::CTRL_SET_EXT_INPUT,
+                           extInputOptions, 9, "ext_input");
+
+    publishSwitchDiscovery("Force Heating", o2mqtt::FORCE_HEATING, o2mqtt::CTRL_FORCE_HEAT, "force_heating");
+
+    Serial.println("[o2mqtt] HA discovery published");
+}
+
+// --- Command handling ---
+
+void Optitronic2MQTTTask::handleMessage(const String& topic, const String& payload)
+{
+    if (topic.endsWith("waterTempTarget"))
+    {
+        float temp = payload.toFloat();
+        if (temp >= 35.0f && temp <= 70.0f)
+        {
+            handleSetDhwSetpoint(temp);
+        }
+    }
+    else if (topic.endsWith("operationMode"))
+    {
+        if (payload == o2mqtt::ENUM_PROGRAM_NORMAL)
+            handleSetProgram(PROGRAM_NORMAL);
+        else if (payload == o2mqtt::ENUM_PROGRAM_ECO)
+            handleSetProgram(PROGRAM_ECO);
+        else if (payload == o2mqtt::ENUM_PROGRAM_KOMFORT)
+            handleSetProgram(PROGRAM_KOMFORT);
+        else if (payload == o2mqtt::ENUM_PROGRAM_KOMFORT_PLUS)
+            handleSetProgram(PROGRAM_KOMFORT_PLUS);
+    }
+    else if (topic.endsWith("extInputFunction"))
+    {
+        if (payload == o2mqtt::ENUM_EXT_QUICK_HEAT)
+            handleSetExtInputFunction(EXT_INPUT_QUICK_HEAT);
+        else if (payload == o2mqtt::ENUM_EXT_OFF)
+            handleSetExtInputFunction(EXT_INPUT_OFF);
+        else if (payload == o2mqtt::ENUM_EXT_NORMAL)
+            handleSetExtInputFunction(EXT_INPUT_NORMAL);
+        else if (payload == o2mqtt::ENUM_EXT_ECO)
+            handleSetExtInputFunction(EXT_INPUT_ECO);
+        else if (payload == o2mqtt::ENUM_EXT_KOMFORT)
+            handleSetExtInputFunction(EXT_INPUT_KOMFORT);
+        else if (payload == o2mqtt::ENUM_EXT_KOMFORT_PLUS)
+            handleSetExtInputFunction(EXT_INPUT_KOMFORT_PLUS);
+        else if (payload == o2mqtt::ENUM_EXT_PV)
+            handleSetExtInputFunction(EXT_INPUT_PHOTOVOLTAIK);
+        else if (payload == o2mqtt::ENUM_EXT_RESERVE)
+            handleSetExtInputFunction(EXT_INPUT_RESERVE);
+        else if (payload == o2mqtt::ENUM_EXT_FUNCTION1)
+            handleSetExtInputFunction(EXT_INPUT_FUNCTION_1);
+    }
+    else if (topic.endsWith("forceHeating"))
+    {
+        handleSetForceHeating(payload == "1");
+    }
+    else if (topic.endsWith("quickHeat"))
+    {
+        // Payload: "1" to activate (uses current target), "0" to deactivate
+        // Or JSON: {"active": true, "target": 43.5}
+        if (payload == "1")
+        {
+            handleSetQuickHeat(true, 0);  // use existing target
+        }
+        else if (payload == "0")
+        {
+            handleSetQuickHeat(false, 0);
+        }
+    }
+    else if (topic.endsWith("triggerAntiLegionella"))
+    {
+        if (payload == "1")
+        {
+            handleTriggerAntiLegionella();
+        }
+    }
+    else if (topic.endsWith("reset"))
+    {
+        if (payload == "1")
+        {
+            ESP.restart();
+        }
+    }
+}
+
+void Optitronic2MQTTTask::handleSetDhwSetpoint(float temp)
+{
+    uint16_t reg   = REG_DHW_SETPOINT;
+    uint16_t value = tempToReg(temp);
+
+    if (xSemaphoreTake(mWriteMutex, pdMS_TO_TICKS(100)))
+    {
+        for (auto& cmd : mWriteQueue)
+        {
+            if (!cmd.pending)
+            {
+                cmd.reg     = reg;
+                cmd.value   = value;
+                cmd.pending = true;
+                break;
+            }
+        }
+        xSemaphoreGive(mWriteMutex);
+    }
+}
+
+void Optitronic2MQTTTask::handleSetProgram(uint16_t program)
+{
+    if (xSemaphoreTake(mWriteMutex, pdMS_TO_TICKS(100)))
+    {
+        for (auto& cmd : mWriteQueue)
+        {
+            if (!cmd.pending)
+            {
+                cmd.reg     = REG_PROGRAM;
+                cmd.value   = program;
+                cmd.pending = true;
+                break;
+            }
+        }
+        xSemaphoreGive(mWriteMutex);
+    }
+}
+
+void Optitronic2MQTTTask::handleSetExtInputFunction(uint16_t fn)
+{
+    if (xSemaphoreTake(mWriteMutex, pdMS_TO_TICKS(100)))
+    {
+        for (auto& cmd : mWriteQueue)
+        {
+            if (!cmd.pending)
+            {
+                cmd.reg     = REG_EXT_INPUT_FUNCTION;
+                cmd.value   = fn;
+                cmd.pending = true;
+                break;
+            }
+        }
+        xSemaphoreGive(mWriteMutex);
+    }
+}
+
+void Optitronic2MQTTTask::handleSetForceHeating(bool enable)
+{
+    if (xSemaphoreTake(mWriteMutex, pdMS_TO_TICKS(100)))
+    {
+        for (auto& cmd : mWriteQueue)
+        {
+            if (!cmd.pending)
+            {
+                cmd.reg     = REG_FORCE_HEATING;
+                cmd.value   = enable ? 1 : 0;
+                cmd.pending = true;
+                break;
+            }
+        }
+        xSemaphoreGive(mWriteMutex);
+    }
+}
+
+void Optitronic2MQTTTask::handleSetQuickHeat(bool activate, float target)
+{
+    // Get current quick heat register value for the target
+    uint16_t currentReg = 0;
+    Optitronic2State::getInstance().getRegister(REG_QUICK_HEAT_STATE, currentReg);
+    uint16_t currentTarget = getQuickHeatTarget(currentReg);
+
+    uint16_t value;
+    if (activate)
+    {
+        uint16_t targetReg = (target > 0) ? tempToReg(target) : currentTarget;
+        value = makeQuickHeatActivate(targetReg);
+    }
+    else
+    {
+        value = currentTarget;  // just the target without bit15
+    }
+
+    if (xSemaphoreTake(mWriteMutex, pdMS_TO_TICKS(100)))
+    {
+        for (auto& cmd : mWriteQueue)
+        {
+            if (!cmd.pending)
+            {
+                cmd.reg     = REG_QUICK_HEAT_STATE;
+                cmd.value   = value;
+                cmd.pending = true;
+                break;
+            }
+        }
+        xSemaphoreGive(mWriteMutex);
+    }
+}
+
+void Optitronic2MQTTTask::handleTriggerAntiLegionella()
+{
+    if (xSemaphoreTake(mWriteMutex, pdMS_TO_TICKS(100)))
+    {
+        for (auto& cmd : mWriteQueue)
+        {
+            if (!cmd.pending)
+            {
+                cmd.reg     = REG_ANTI_LEGIONELLA;
+                cmd.value   = 1;
+                cmd.pending = true;
+                break;
+            }
+        }
+        xSemaphoreGive(mWriteMutex);
+    }
+}
+
+// --- Write queue interface for ModbusListenerTask ---
+
+bool Optitronic2MQTTTask::hasPendingWrite() const
+{
+    for (const auto& cmd : mWriteQueue)
+    {
+        if (cmd.pending)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Optitronic2MQTTTask::dequeuePendingWrite(uint16_t& reg, uint16_t& value)
+{
+    if (!xSemaphoreTake(mWriteMutex, pdMS_TO_TICKS(10)))
+    {
+        return false;
+    }
+
+    bool found = false;
+    for (auto& cmd : mWriteQueue)
+    {
+        if (cmd.pending)
+        {
+            reg         = cmd.reg;
+            value       = cmd.value;
+            cmd.pending = false;
+            found       = true;
+            break;
+        }
+    }
+
+    xSemaphoreGive(mWriteMutex);
+    return found;
+}
+
+// --- Publish helpers ---
+
+void Optitronic2MQTTTask::publishFloat(const char* subtopic, float value, uint8_t decimals)
+{
+    snprintf(mTopicBuffer, sizeof(mTopicBuffer), "%s%s", o2mqtt::BASE, subtopic);
+    dtostrf(value, 1, decimals, mPayloadBuffer);
+    mMQTTClient.publish(mTopicBuffer, mPayloadBuffer, true, 0);
+}
+
+void Optitronic2MQTTTask::publishInt(const char* subtopic, int value)
+{
+    snprintf(mTopicBuffer, sizeof(mTopicBuffer), "%s%s", o2mqtt::BASE, subtopic);
+    snprintf(mPayloadBuffer, sizeof(mPayloadBuffer), "%d", value);
+    mMQTTClient.publish(mTopicBuffer, mPayloadBuffer, true, 0);
+}
+
+void Optitronic2MQTTTask::publishString(const char* subtopic, const char* value)
+{
+    snprintf(mTopicBuffer, sizeof(mTopicBuffer), "%s%s", o2mqtt::BASE, subtopic);
+    mMQTTClient.publish(mTopicBuffer, value, true, 0);
+}
+
+void Optitronic2MQTTTask::publishBool(const char* subtopic, bool value)
+{
+    snprintf(mTopicBuffer, sizeof(mTopicBuffer), "%s%s", o2mqtt::BASE, subtopic);
+    mMQTTClient.publish(mTopicBuffer, value ? "1" : "0", true, 0);
+}
+
+}  // namespace aquamqtt

--- a/AquaMQTT/src/task/Optitronic2MQTTTask.cpp
+++ b/AquaMQTT/src/task/Optitronic2MQTTTask.cpp
@@ -29,6 +29,8 @@ constexpr char PV_ACTIVE[]          = "statePV";
 constexpr char ACTIVE_SETPOINT[]    = "activeSetpoint";
 constexpr char OPERATING_STATE[]    = "operatingState";
 constexpr char QUICK_HEAT_ACTIVE[]  = "quickHeatActive";
+constexpr char HEAT_SOURCE[]        = "heatSource";
+constexpr char COMPRESSOR_STATUS[]  = "heatingTrigger";
 
 // Settings topics (read + writable)
 constexpr char DHW_SETPOINT[]       = "waterTempTarget";
@@ -89,6 +91,7 @@ constexpr char ENUM_EXT_FUNCTION1[]    = "FUNCTION1";
 
 // Operating state enum strings
 constexpr char ENUM_STATE_IDLE[]     = "IDLE";
+constexpr char ENUM_STATE_HEATING[]  = "HEATING";
 constexpr char ENUM_STATE_PV_BOOST[] = "PV_BOOST";
 constexpr char ENUM_STATE_UNKNOWN[]  = "UNKNOWN";
 
@@ -196,6 +199,10 @@ void Optitronic2MQTTTask::loop()
     if (notifyValue & Optitronic2State::CHANGE_INSTALLER)
     {
         publishInstaller();
+    }
+    if (notifyValue & Optitronic2State::CHANGE_SCHEDULE)
+    {
+        publishInstaller();  // schedule is published inside publishInstaller
     }
 
     // Full update every 60s regardless of changes
@@ -354,8 +361,11 @@ void Optitronic2MQTTTask::publishState()
     const char* stateStr = o2mqtt::ENUM_STATE_UNKNOWN;
     switch (state.getOperatingState())
     {
-        case STATE_IDLE_HEATING:
+        case STATE_IDLE:
             stateStr = o2mqtt::ENUM_STATE_IDLE;
+            break;
+        case STATE_HEATING:
+            stateStr = o2mqtt::ENUM_STATE_HEATING;
             break;
         case STATE_PV_BOOST:
             stateStr = o2mqtt::ENUM_STATE_PV_BOOST;
@@ -363,6 +373,25 @@ void Optitronic2MQTTTask::publishState()
     }
     publishString(o2mqtt::OPERATING_STATE, stateStr);
     publishBool(o2mqtt::QUICK_HEAT_ACTIVE, state.isQuickHeatActive());
+
+    // Heat source active
+    const char* heatSrcStr = "OFF";
+    switch (state.getHeatSource())
+    {
+        case HEAT_SRC_ELECTRIC:  heatSrcStr = "ELECTRIC"; break;
+        case HEAT_SRC_HEATPUMP:  heatSrcStr = "HEATPUMP"; break;
+        case HEAT_SRC_BOTH:      heatSrcStr = "BOTH"; break;
+    }
+    publishString(o2mqtt::HEAT_SOURCE, heatSrcStr);
+
+    // Compressor status
+    const char* compStr = "IDLE";
+    switch (state.getCompressorStatus())
+    {
+        case COMP_RUNNING:    compStr = "RUNNING"; break;
+        case COMP_PV_ACTIVE:  compStr = "PV_ACTIVE"; break;
+    }
+    publishString(o2mqtt::COMPRESSOR_STATUS, compStr);
 }
 
 void Optitronic2MQTTTask::publishInstaller()
@@ -380,6 +409,46 @@ void Optitronic2MQTTTask::publishInstaller()
         publishFloat(o2mqtt::BIVALENT_THRESHOLD, state.getBivalentThreshold());
         publishFloat(o2mqtt::PV_TARGET, state.getPvTargetSetpoint());
         publishFloat(o2mqtt::EXT_MAX_TEMP, state.getExtSourceMaxTemp());
+    }
+
+    // Publish DHW schedule as JSON if available
+    if (state.hasBlock(REG_SCHEDULE_DHW_START))
+    {
+        String json = "[";
+        static const char* days[] = {"Mon","Tue","Wed","Thu","Fri","Sat","Sun"};
+        for (int d = 0; d < 7; d++)
+        {
+            if (d > 0) json += ",";
+            json += "{\"day\":\"";
+            json += days[d];
+            json += "\",\"slots\":[";
+            for (int s = 0; s < 3; s++)
+            {
+                uint16_t sv, ev;
+                uint16_t sr = REG_SCHEDULE_DHW_START + d * 6 + s * 2;
+                uint16_t er = sr + 1;
+                state.getRegister(sr, sv);
+                state.getRegister(er, ev);
+                if (s > 0) json += ",";
+                if (sv == SCHED_DISABLED)
+                {
+                    json += "null";
+                }
+                else
+                {
+                    uint8_t sh = ((sv & SCHED_TIME_MASK) * 15) / 60;
+                    uint8_t sm = ((sv & SCHED_TIME_MASK) * 15) % 60;
+                    uint8_t eh = ((ev & SCHED_TIME_MASK) * 15) / 60;
+                    uint8_t em = ((ev & SCHED_TIME_MASK) * 15) % 60;
+                    char buf[32];
+                    snprintf(buf, sizeof(buf), "\"%02d:%02d-%02d:%02d\"", sh, sm, eh, em);
+                    json += buf;
+                }
+            }
+            json += "]}";
+        }
+        json += "]";
+        publishString("schedule/dhw", json.c_str());
     }
 }
 

--- a/PROTOCOL_OPTITRONIC2.md
+++ b/PROTOCOL_OPTITRONIC2.md
@@ -1,0 +1,206 @@
+# Optitronic 2 Serial Protocol
+
+## Overview
+
+The Optitronic 2 protocol is used by Austria Email / Groupe Atlantic heat pump water heaters with the "Optitronic 2" HMI controller. Unlike the other protocols supported by AquaMQTT (which use a proprietary serial format), the Optitronic 2 uses **standard Modbus RTU** on the serial bus between the HMI controller (master) and the main controller (slave).
+
+### Compatible Devices
+
+- Austria Email WPA 450 ECO
+- Austria Email EKR 450 (with Optitronic 2 controller)
+- Other Groupe Atlantic devices using the Optitronic 2 HMI (to be confirmed)
+
+### Bus Parameters
+
+| Parameter      | Value                                    |
+|----------------|------------------------------------------|
+| Wire protocol  | Modbus RTU, CRC-16/Modbus               |
+| Baud rate      | 57600                                    |
+| Data format    | 8N1                                      |
+| Logic levels   | 5V TTL (via SN74LVC2T45 level shifter)  |
+| Master         | HMI controller                           |
+| Slave address  | `0x01` (main controller)                 |
+| Polling rate   | ~1.7 Hz (5 read blocks per cycle)        |
+| Write functions| `fn=0x06` (single register), `fn=0x10` (multiple registers) |
+
+## Architecture
+
+```
+┌──────────┐     Modbus RTU      ┌──────────────┐
+│   HMI    │◄───────────────────►│    Main      │
+│ (Master) │     57600 8N1       │ (Slave 0x01) │
+└──────────┘                     └──────────────┘
+       │
+       │  (passive tap via level shifter)
+       │
+┌──────────────┐
+│   AquaMQTT   │
+│   (ESP32)    │──── WiFi ──── MQTT Broker ──── Home Assistant
+└──────────────┘
+```
+
+In **LISTENER** mode, AquaMQTT passively sniffs the bus and decodes both master requests (to track register addresses) and slave responses (to extract register data). It publishes decoded values to MQTT and accepts commands which are injected onto the bus during idle periods.
+
+## Register Map
+
+### Periodic Read Blocks
+
+The HMI polls these blocks every ~600ms cycle:
+
+| Block | Start  | Qty | Content                                        |
+|-------|--------|-----|------------------------------------------------|
+| 1     | 0x0000 | 25  | Settings + operating state                     |
+| 2     | 0x00C8 | 10  | Sensor data (temperatures, PV status)          |
+| 3     | 0x00E1 | 6   | Status flags                                   |
+| 4     | 0x0197 | 1   | Unknown (always 0)                             |
+| 5     | 0x0320 | 1   | Unknown (always 0)                             |
+
+### On-Demand Blocks
+
+Read only when user navigates specific menus:
+
+| Block          | Start  | Qty | Trigger                  |
+|----------------|--------|-----|--------------------------|
+| DHW Schedule   | 0x0032 | 42  | Schedule menu            |
+| Installer 1    | 0x015E | 25  | Installer PIN entry      |
+| Installer 2    | 0x0190 | 25  | Installer PIN entry      |
+| Vent Schedule  | 0x01C2 | 42  | Installer menu only      |
+
+### User Settings (writable, fn=0x06)
+
+| Register | Name                  | Encoding          | Default     |
+|----------|-----------------------|-------------------|-------------|
+| 0x0009   | DHW setpoint          | int16 ×0.1°C      | 550 (55°C)  |
+| 0x000A   | ECO deviation         | signed int16 ×0.1°C | -100 (-10°C) |
+| 0x000B   | Komfort deviation     | int16 ×0.1°C      | 20 (+2°C)   |
+| 0x000C   | Program               | enum (1-4)        | 2 (ECO)     |
+| 0x000D   | Aux heat source mode  | enum (1-3)        | 3 (both)    |
+| 0x000F   | Force heating         | bool              | 0           |
+| 0x0010   | Trigger anti-legionella | bool            | 0           |
+| 0x0011   | External input function | enum (0-8)      | 6 (PV)      |
+| 0x0016   | Quick-heat state      | int16 (bit15=activate) | 0x01B3 |
+
+### Program Enum (reg 0x000C)
+
+| Value | Name          |
+|-------|---------------|
+| 1     | NORMAL        |
+| 2     | ECO           |
+| 3     | KOMFORT       |
+| 4     | KOMFORT PLUS  |
+
+### External Input Function Enum (reg 0x0011)
+
+| Value | Function                           |
+|-------|------------------------------------|
+| 0     | Schnellaufheizung (Quick Heat)     |
+| 1     | OFF (remote shutdown)              |
+| 2     | NORMAL                             |
+| 3     | ECO                                |
+| 4     | KOMFORT                            |
+| 5     | KOMFORT PLUS                       |
+| 6     | PHOTOVOLTAIK                       |
+| 7     | Reservequelle                      |
+| 8     | Funktionseingang 1                 |
+
+### Sensor Registers (read-only, block 0x00C8+10)
+
+| Register | Name                | Encoding      |
+|----------|---------------------|---------------|
+| 0x00C8   | Water temp (tank)   | int16 ×0.1°C  |
+| 0x00CA   | Ambient/intake temp | int16 ×0.1°C  |
+| 0x00CB   | Evaporator temp     | int16 ×0.1°C  |
+| 0x00D1   | PV input status     | 0=inactive, 4=active |
+
+### Operating State (from block 0x0000)
+
+| Register | Name            | Encoding                      |
+|----------|-----------------|-------------------------------|
+| 0x0000   | Active setpoint | int16 ×0.1°C (effective)      |
+| 0x0001   | Operating state | 2=idle/heating, 6=PV-boost    |
+| 0x0016   | Quick-heat      | bit15=active, lower=target    |
+
+### Quick-Heat Mechanism
+
+Register 0x0016 serves dual purpose:
+- **Read**: Current quick-heat target temperature (lower 15 bits × 0.1°C) + active flag (bit 15)
+- **Write 0x81B3**: Activate quick-heat to 43.5°C (bit15 set + target)
+- **Write 0x01B3**: Cancel quick-heat (just target, no bit15)
+
+### PV Boost Detection
+
+| Condition     | 0x0000 (setpoint) | 0x0001 (state) | 0x00D1 (PV) |
+|---------------|-------------------|----------------|--------------|
+| No PV         | 450 (45.0°C)      | 2              | 0            |
+| PV active     | 700 (70.0°C)      | 6              | 4            |
+
+Best indicator: `reg 0x00D1` → 0 = no PV, 4 = PV active.
+
+### Installer Registers
+
+| Register | Name                  | Default       |
+|----------|-----------------------|---------------|
+| 0x0160   | Frost protection temp | 70 (7.0°C)    |
+| 0x019F   | PV target setpoint    | 700 (70.0°C)  |
+| 0x01A0   | Bivalent threshold    | 30 (3.0°C)    |
+| 0x01A3   | Ext source max temp   | 600 (60.0°C)  |
+
+## MQTT Topics
+
+All topics are prefixed with `aquamqtt/` (configurable via `mqttPrefix`).
+
+### Published (read-only sensors)
+
+| Topic                        | Type    | Description                    |
+|------------------------------|---------|--------------------------------|
+| `aquamqtt/waterTemp`         | float   | Tank water temperature (°C)    |
+| `aquamqtt/supplyAirTemp`     | float   | Ambient/intake air temp (°C)   |
+| `aquamqtt/evaporatorTemp`    | float   | Evaporator temperature (°C)    |
+| `aquamqtt/statePV`           | bool    | PV input active (1/0)          |
+| `aquamqtt/activeSetpoint`    | float   | Current effective setpoint (°C)|
+| `aquamqtt/operatingState`    | string  | IDLE / PV_BOOST / UNKNOWN      |
+| `aquamqtt/quickHeatActive`   | bool    | Quick heat active (1/0)        |
+
+### Published (settings, also writable via ctrl/)
+
+| Topic                        | Type    | Description                    |
+|------------------------------|---------|--------------------------------|
+| `aquamqtt/waterTempTarget`   | float   | DHW setpoint (°C)              |
+| `aquamqtt/operationMode`     | string  | NORMAL/ECO/KOMFORT/KOMFORT_PLUS|
+| `aquamqtt/auxHeatMode`       | string  | ELECTRIC/EXTERNAL/BOTH         |
+| `aquamqtt/extInputFunction`  | string  | External input function        |
+| `aquamqtt/forceHeating`      | bool    | Force heating active           |
+
+### Control (subscribe to write)
+
+| Topic                              | Payload                           |
+|------------------------------------|-----------------------------------|
+| `aquamqtt/ctrl/waterTempTarget`    | Temperature as float (35.0-70.0)  |
+| `aquamqtt/ctrl/operationMode`      | NORMAL/ECO/KOMFORT/KOMFORT_PLUS   |
+| `aquamqtt/ctrl/extInputFunction`   | Enum string (see above)           |
+| `aquamqtt/ctrl/forceHeating`       | 1 or 0                            |
+| `aquamqtt/ctrl/quickHeat`          | 1 (activate) or 0 (cancel)       |
+| `aquamqtt/ctrl/triggerAntiLegionella` | 1                              |
+| `aquamqtt/ctrl/reset`              | 1 (reboot ESP)                    |
+
+## Configuration
+
+To use the Optitronic 2 mode, set in `Configuration.h`:
+
+```cpp
+constexpr EOperationMode OPERATION_MODE = EOperationMode::OPTITRONIC2_LISTENER;
+```
+
+The serial configuration is fixed at 57600 baud, 8N1 (hardcoded in the Modbus listener task, as required by the Optitronic 2 protocol).
+
+## Hardware Wiring
+
+The wiring is simpler than the MITM mode — only one serial connection is needed (passive tap):
+
+- Connect the ESP32 RX pin to the data line between HMI and main controller (via level shifter)
+- For write support, also connect the TX pin to the same data line
+- The SN74LVC2T45 level shifter from the standard AquaMQTT PCB works for this purpose
+
+## Protocol Discovery
+
+This protocol was reverse-engineered from an Austria Email WPA 450 ECO through two capture sessions (95 total captures) using an ESP32 TCP raw listener and custom decode/analysis tools. See the [device reference documentation](https://tome.corp.wal.tl:8080/knowledge/reference/austria-email-wpa450eco-reference) for the full capture analysis.


### PR DESCRIPTION
## Summary

Add full support for the **Optitronic 2** protocol used by Austria Email WPA 450 ECO and similar Groupe Atlantic heat pump water heaters that communicate via standard **Modbus RTU** (57600 8N1) instead of the proprietary Atlantic protocol.

This PR introduces two operation modes, a complete protocol implementation reverse-engineered from 95+ bus captures, full MQTT integration with Home Assistant auto-discovery, and a one-wire MITM relay for active control.

**Base:** `main`  
**29 files changed**, +3 945 / −40 lines

---

## New Operation Modes

### `OPTITRONIC2_LISTENER` — Passive Bus Sniffing
- Sniffs the Modbus RTU bus between HMI (master) and controller (slave 0x01)
- Parses `fn=0x03` read responses, `fn=0x06` single writes, `fn=0x10` multi writes
- Frame boundary detection via inter-character silence (2 ms threshold)
- Register-based state store with change tracking and notification

### `OPTITRONIC2_MITM` — Active MITM Relay
- One-wire UART MITM relay using ESP32-S3 GPIO matrix
- Solves SN74LVC2T45 bus contention by disconnecting UART TX idle-HIGH during receive and mirroring TX to both A1+A2 pins during transmit
- Bidirectional HMI ↔ Main frame forwarding with write injection during bus idle periods

---

## Protocol Mapping (Reverse-Engineered)

- 5 periodic read blocks (settings, sensors, status)
- 4 on-demand blocks (schedules, installer parameters)
- 9 writable user registers (including quick-heat bit15 mechanism)
- Full enum mappings for program, ext-input function, operating state, PV status
- Documented in `PROTOCOL_OPTITRONIC2.md`

---

## MQTT Features

### Published Topics
All decoded register values: temperatures, setpoints, states, programs, heat source, compressor status, fan level, DHW schedule (JSON), operating state (with raw diagnostic value).

### Operating States
`OFF` · `STANDBY` · `IDLE` · `HEATING` · `HEATING_ELECTRIC` · `HEATING_BOTH` · `PV_BOOST` · `DEFROST` · `ANTI_LEGIONELLA`

### Control Topics (`aquamqtt/ctrl/#`)
`setpoint` · `program` · `extInputFunction` · `forceHeating` · `quickHeat` · `antiLegionellaTrigger` · `ecoDeviation` · `komfortDeviation` · `auxHeatMode` · `pvTargetSetpoint` · `antiLegionellaInterval` · `frostProtectTemp` · `extSourcePriority` · `bivalentThreshold` · `extSourceMaxTemp`

### Home Assistant Auto-Discovery
- 17 sensor entities (temperatures, states, counters)
- 8 number entities (setpoints, installer-level parameters)
- 4 select entities (program, aux heat mode, ext source priority, ext input function)
- 1 switch entity (force heating)

---

## Infrastructure

- **Web handler** with `/api/diag` diagnostics endpoint and config GET endpoints
- **LittleFS config persistence** for WiFi, MQTT, and operation mode (`wifi.json`, `mqtt.json`, `aquamqtt.json`)
- **OTA** support retained
- **Resource usage:** RAM ~17%, Flash ~39%

---

## Commits

1. **feat(optitronic2): add Optitronic 2 Modbus RTU protocol support** — Listener mode, protocol parser, state store, MQTT publishing, HA discovery, protocol documentation
2. **feat(optitronic2): MITM relay with full MQTT control** — One-wire relay, write injection, config persistence, web handler, diagnostics endpoint
3. **feat(optitronic2): protocol reverse-engineering** — Heat source/fan/schedule decoding, additional MQTT topics
4. **feat(optitronic2): add ext source priority, expand HA discovery** — External source priority, full HA discovery for installer-level settings
5. **feat: expand operating state enum with raw diagnostic** — 9 operating states mapped + `operatingStateRaw` diagnostic topic

---

## Testing

- Verified on ESP32-S3 (Waveshare Nano) connected to Austria Email WPA 450 ECO
- OTA deployed and confirmed: state reporting, MQTT control, HA entity creation
- Bus stability tested under continuous operation