### PR TITLE
Enabling Boost mode for the PV-Modes instead of Eco Off

### DIFF
--- a/AquaMQTT/src/state/HMIStateProxy.cpp
+++ b/AquaMQTT/src/state/HMIStateProxy.cpp
@@ -56,14 +56,23 @@ void HMIStateProxy::applyHMIOverrides(uint8_t* buffer, const message::ProtocolVe
         case AM_MODE_PV_HP_ONLY:
             message->setAttr(message::HMI_ATTR_U8::STATE_INSTALLATION_MODE, message::HMIInstallation::INST_HP_ONLY);
             message->setAttr(message::HMI_ATTR_U8::OPERATION_TYPE, message::HMIOperationType::OT_ALWAYS_ON);
-            if (version == message::PROTOCOL_ODYSSEE) {
+            // if (version == message::PROTOCOL_ODYSSEE) {
                 // Odyssee does not have the option to disable the heat element. Therefore, we enter operation mode
                 // ECO ACTIVE (which forbids usage of heat element) and set the target temperature to maximum temperature
                 // This configuration is not allowed in the HMI controller, but we hope the Main controller accepts it :)
-                message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_BOOST);
-            } else {
+                // message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_ECO_ACTIVE);
+            //} else {
+            // Disabling of previous condition because OM_BOOST is also mentionned as available for the Calypso 
                 message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_BOOST);
             }
+                // ECO modes are designed with algorythms based on previous behaviour, while the Boost command is 
+                // on demand only, unregarding of previous behaviour. Depending of the needs of the user
+                // (off hours, grid overproduction shedding actions, solar panels,...), and the habits
+                // of the user (ex: more water usage on certain days than others,..), and the water temp
+                // ECO-modes will prevent te unit from enabling the heatpump. Built in checks prevent 
+                // enabling heatpump/heatelement above factory set temperatures if not already enabled 
+                // (ex: Explorer V4 won't start heating if water is above 58°C and heating was off).
+                // Will not override the refusal of the heatelement
             message->setAttr(message::HMI_ATTR_FLOAT::WATER_TARGET_TEMPERATURE, config::MAX_WATER_TEMPERATURE);
             // do not use heat element
             message->setAttr(message::HMI_ATTR_BOOL::EMERGENCY_MODE_ENABLED, false);
@@ -73,6 +82,7 @@ void HMIStateProxy::applyHMIOverrides(uint8_t* buffer, const message::ProtocolVe
             message->setAttr(message::HMI_ATTR_U8::STATE_INSTALLATION_MODE, message::HMIInstallation::INST_HP_ONLY);
             message->setAttr(message::HMI_ATTR_U8::OPERATION_TYPE, message::HMIOperationType::OT_ALWAYS_ON);
             message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_BOOST);
+            // Same logic as with PV_HP_ONLY
             message->setAttr(message::HMI_ATTR_FLOAT::WATER_TARGET_TEMPERATURE, config::MAX_WATER_TEMPERATURE);
             // just use heat element
             message->setAttr(message::HMI_ATTR_BOOL::EMERGENCY_MODE_ENABLED, true);

--- a/AquaMQTT/src/state/HMIStateProxy.cpp
+++ b/AquaMQTT/src/state/HMIStateProxy.cpp
@@ -60,9 +60,9 @@ void HMIStateProxy::applyHMIOverrides(uint8_t* buffer, const message::ProtocolVe
                 // Odyssee does not have the option to disable the heat element. Therefore, we enter operation mode
                 // ECO ACTIVE (which forbids usage of heat element) and set the target temperature to maximum temperature
                 // This configuration is not allowed in the HMI controller, but we hope the Main controller accepts it :)
-                message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_ECO_ACTIVE);
+                message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_BOOST);
             } else {
-                message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_ECO_INACTIVE);
+                message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_BOOST);
             }
             message->setAttr(message::HMI_ATTR_FLOAT::WATER_TARGET_TEMPERATURE, config::MAX_WATER_TEMPERATURE);
             // do not use heat element
@@ -72,7 +72,7 @@ void HMIStateProxy::applyHMIOverrides(uint8_t* buffer, const message::ProtocolVe
         case AM_MODE_PV_HE_ONLY:
             message->setAttr(message::HMI_ATTR_U8::STATE_INSTALLATION_MODE, message::HMIInstallation::INST_HP_ONLY);
             message->setAttr(message::HMI_ATTR_U8::OPERATION_TYPE, message::HMIOperationType::OT_ALWAYS_ON);
-            message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_ECO_INACTIVE);
+            message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_BOOST);
             message->setAttr(message::HMI_ATTR_FLOAT::WATER_TARGET_TEMPERATURE, config::MAX_WATER_TEMPERATURE);
             // just use heat element
             message->setAttr(message::HMI_ATTR_BOOL::EMERGENCY_MODE_ENABLED, true);

--- a/AquaMQTT/src/state/HMIStateProxy.cpp
+++ b/AquaMQTT/src/state/HMIStateProxy.cpp
@@ -60,7 +60,7 @@ void HMIStateProxy::applyHMIOverrides(uint8_t* buffer, const message::ProtocolVe
                 // Odyssee does not have the option to disable the heat element. Therefore, we enter operation mode
                 // ECO ACTIVE (which forbids usage of heat element) and set the target temperature to maximum temperature
                 // This configuration is not allowed in the HMI controller, but we hope the Main controller accepts it :)
-                 message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_ECO_ACTIVE);
+                message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_ECO_ACTIVE);
             } else {
                 message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_BOOST);
             }

--- a/AquaMQTT/src/state/HMIStateProxy.cpp
+++ b/AquaMQTT/src/state/HMIStateProxy.cpp
@@ -65,13 +65,8 @@ void HMIStateProxy::applyHMIOverrides(uint8_t* buffer, const message::ProtocolVe
                 message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_BOOST);
             }
                 // ECO modes are designed with algorythms based on previous behaviour, while the Boost command is 
-                // on demand only, unregarding of previous behaviour. Depending of the needs of the user
-                // (off hours, grid overproduction shedding actions, solar panels,...), and the habits
-                // of the user (ex: more water usage on certain days than others,..), and the water temp
-                // ECO-modes will prevent te unit from enabling the heatpump. Built in checks prevent 
-                // enabling heatpump/heatelement above factory set temperatures if not already enabled 
-                // (ex: Explorer V4 won't start heating if water is above 58°C and heating was off).
-                // Will not override the refusal of the heatelement. Testing needed to see if Calypso
+                // on demand only, unregarding of previous behaviour. Built in checks prevent 
+                // enabling above factory-set temperatures. Will not override the refusal of the heatelement. Testing needed to see if Calypso
                 // accepts Boost instead of ECO_ACTIVE while still accepting refusal of HE.
             message->setAttr(message::HMI_ATTR_FLOAT::WATER_TARGET_TEMPERATURE, config::MAX_WATER_TEMPERATURE);
             // do not use heat element

--- a/AquaMQTT/src/state/HMIStateProxy.cpp
+++ b/AquaMQTT/src/state/HMIStateProxy.cpp
@@ -56,13 +56,12 @@ void HMIStateProxy::applyHMIOverrides(uint8_t* buffer, const message::ProtocolVe
         case AM_MODE_PV_HP_ONLY:
             message->setAttr(message::HMI_ATTR_U8::STATE_INSTALLATION_MODE, message::HMIInstallation::INST_HP_ONLY);
             message->setAttr(message::HMI_ATTR_U8::OPERATION_TYPE, message::HMIOperationType::OT_ALWAYS_ON);
-            // if (version == message::PROTOCOL_ODYSSEE) {
+            if (version == message::PROTOCOL_ODYSSEE) {
                 // Odyssee does not have the option to disable the heat element. Therefore, we enter operation mode
                 // ECO ACTIVE (which forbids usage of heat element) and set the target temperature to maximum temperature
                 // This configuration is not allowed in the HMI controller, but we hope the Main controller accepts it :)
-                // message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_ECO_ACTIVE);
-            //} else {
-            // Disabling of previous condition because OM_BOOST is also mentionned as available for the Calypso 
+                 message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_ECO_ACTIVE);
+            } else {
                 message->setAttr(message::HMI_ATTR_U8::OPERATION_MODE, message::HMIOperationMode::OM_BOOST);
             }
                 // ECO modes are designed with algorythms based on previous behaviour, while the Boost command is 
@@ -72,7 +71,8 @@ void HMIStateProxy::applyHMIOverrides(uint8_t* buffer, const message::ProtocolVe
                 // ECO-modes will prevent te unit from enabling the heatpump. Built in checks prevent 
                 // enabling heatpump/heatelement above factory set temperatures if not already enabled 
                 // (ex: Explorer V4 won't start heating if water is above 58°C and heating was off).
-                // Will not override the refusal of the heatelement
+                // Will not override the refusal of the heatelement. Testing needed to see if Calypso
+                // accepts Boost instead of ECO_ACTIVE while still accepting refusal of HE.
             message->setAttr(message::HMI_ATTR_FLOAT::WATER_TARGET_TEMPERATURE, config::MAX_WATER_TEMPERATURE);
             // do not use heat element
             message->setAttr(message::HMI_ATTR_BOOL::EMERGENCY_MODE_ENABLED, false);

--- a/BOILER-OPERATION-MODES.md
+++ b/BOILER-OPERATION-MODES.md
@@ -1,0 +1,39 @@
+## Boiler Operation Modes
+
+Atlantic allows for 4 normal operation modes for their boilers, with each their own use case. 
+The nuances between each mode can be relevant or ignored deping of use case.
+
+The information here has been found though installers manuals and commercial information.
+Some differences should be expected between generations of models.
+
+### Operation Modes
+
+1. **AUTO**
+	Integrated algorithms take into account the data from the sensors to decide when it's 
+	better to generate hot water and how. So the HMI is trying to optimise the usage of 
+	heat-pump while using the heating element depending of what happened the previous days. 
+	It accepts the time schedules defined by the user. It is unclear if MITM changes are well
+	integrated in this mode.
+	
+2. **Manual ECO Off**
+	Unit uses only the heat-pump to generate hot water, except if the outside air is too cold 
+	or there has been a lot of water usage. There is probably an algorythm behind this mode. It
+	also supposed to be allowing time programmations. Enabling this mode does not automatically
+	start heating.
+	
+3. **Manual ECO On**
+	Similar to Manual Eco Off, but with the Heatpump being enabled when the outside air is between 
+	-5°C and 43°. The heat-element is then disabled. 
+	
+4. **BOOST**
+	Directly starts the heating process. When toggled, both the heat-pump and heat-element are 
+	enabled, except	if one of them has been flagged as disabled (like in the PV-modes). At least 
+	some boilers have a limit set in their firmware that prevents the activation of heating if 
+	the water temperature is above a certain value. If the heating process was already on, that 
+	limit can be overtaken by the unit. Example: on the Explorer V4, this limit seems to be at 58°C.
+	
+5. **Absence**
+	Water temperature is set at 15°C and will be heated using the resistance when dropping below
+	this value. When setting the operation mode back to another mode, the boiler will directly 
+	start to heat water. If the temperature is too low, it will enable the heating-element under 
+	emergency-mode. 

--- a/BOILER-OPERATION-MODES.md
+++ b/BOILER-OPERATION-MODES.md
@@ -1,7 +1,8 @@
 ## Boiler Operation Modes
 
 Atlantic allows for 4 normal operation modes for their boilers, with each their own use case. 
-The nuances between each mode can be relevant or ignored deping of use case.
+The nuances between each mode can be relevant or ignored depending of use case. There is also an 
+absence mode.
 
 The information here has been found though installers manuals and commercial information.
 Some differences should be expected between generations of models.


### PR DESCRIPTION
Resolves issue [119](https://github.com/tspopp/AquaMQTT/issues/119). 

Forces the PV-modes to enable heating without having the boiler's factory algorithms or limits preventing the start of heating. Setting to boost mode does not prevent flagging one part of the boiler disabled for the PV-modes (ex: PV-HP-Only under boost will only trigger the start of the heat-pump since the heat-element is flagged as disabled). Left the conditional for the Calypso boilers with ECO ON for the PV-HP-Only mode. Boost mode could probably also better for this usage but since it seems different enough from the other boilers, this should be tested before merged. 

Also made a separate readme file for the different Operation Modes of the boilers with what I could reunite between installer guides and commercial stuff. 